### PR TITLE
Add DB scripts and failover connection module

### DIFF
--- a/conexion/conexion.py
+++ b/conexion/conexion.py
@@ -1,0 +1,109 @@
+import json
+import logging
+import os
+from typing import Any, List, Tuple
+
+import mysql.connector
+from mysql.connector import MySQLConnection, Error
+from dotenv import load_dotenv
+
+
+class ConexionBD:
+    """Manejo de dos conexiones MySQL con failover y cola de operaciones."""
+
+    def __init__(self) -> None:
+        load_dotenv()
+        self.local_conf = {
+            'host': os.getenv('DB_LOCAL_HOST', '127.0.0.1'),
+            'user': os.getenv('DB_USER', 'root'),
+            'password': os.getenv('DB_PASSWORD', ''),
+            'database': os.getenv('DB_NAME', 'alquiler_vehiculos'),
+        }
+        self.remote_conf = {
+            'host': os.getenv('DB_REMOTE_HOST', '192.168.0.2'),
+            'user': os.getenv('DB_USER', 'root'),
+            'password': os.getenv('DB_PASSWORD', ''),
+            'database': os.getenv('DB_NAME', 'alquiler_vehiculos'),
+        }
+        self.active = 'local'
+        self.conn: MySQLConnection | None = None
+        self.queue_file = 'pendientes.json'
+        self._cargar_pendientes()
+        logging.basicConfig(level=logging.INFO,
+                            format='%(asctime)s - %(levelname)s - %(message)s')
+        self.conectar()
+
+    def _cargar_pendientes(self) -> None:
+        if os.path.exists(self.queue_file):
+            with open(self.queue_file, 'r', encoding='utf-8') as f:
+                self.pendientes: List[dict[str, Any]] = json.load(f)
+        else:
+            self.pendientes = []
+
+    def _guardar_pendientes(self) -> None:
+        with open(self.queue_file, 'w', encoding='utf-8') as f:
+            json.dump(self.pendientes, f, ensure_ascii=False, indent=2)
+
+    def conectar(self) -> None:
+        config = self.local_conf if self.active == 'local' else self.remote_conf
+        try:
+            self.conn = mysql.connector.connect(**config)
+            logging.info('Conectado a base %s', self.active)
+            self._sincronizar()
+        except Error as e:
+            logging.error('Error al conectar a base %s: %s', self.active, e)
+            self._failover()
+
+    def _failover(self) -> None:
+        self.active = 'remote' if self.active == 'local' else 'local'
+        config = self.local_conf if self.active == 'local' else self.remote_conf
+        try:
+            self.conn = mysql.connector.connect(**config)
+            logging.info('Conmutación a base %s exitosa', self.active)
+            self._sincronizar()
+        except Error as e:
+            logging.error('Failover fallido: %s', e)
+            self.conn = None
+
+    def ejecutar(self, query: str, params: Tuple[Any, ...] | None = None) -> List[Tuple[Any, ...]]:
+        if not self.conn or not self.conn.is_connected():
+            self.conectar()
+        if not self.conn:
+            self._agregar_pendiente(query, params)
+            raise ConnectionError('No hay conexión disponible')
+        try:
+            cur = self.conn.cursor()
+            cur.execute(query, params)
+            if query.strip().lower().startswith('select'):
+                resultados = cur.fetchall()
+            else:
+                self.conn.commit()
+                resultados = []
+            return resultados
+        except Error as e:
+            logging.error('Error ejecutando consulta: %s', e)
+            self._agregar_pendiente(query, params)
+            self._failover()
+            raise
+
+    def _agregar_pendiente(self, query: str, params: Tuple[Any, ...] | None) -> None:
+        self.pendientes.append({'query': query, 'params': params})
+        self._guardar_pendientes()
+        logging.info('Consulta almacenada en cola de pendientes')
+
+    def _sincronizar(self) -> None:
+        if not self.pendientes or not self.conn or not self.conn.is_connected():
+            return
+        logging.info('Sincronizando %d operaciones pendientes', len(self.pendientes))
+        while self.pendientes:
+            op = self.pendientes.pop(0)
+            try:
+                cur = self.conn.cursor()
+                cur.execute(op['query'], op['params'])
+                if not op['query'].strip().lower().startswith('select'):
+                    self.conn.commit()
+            except Error as e:
+                logging.error('Error al sincronizar: %s', e)
+                self.pendientes.insert(0, op)
+                break
+        self._guardar_pendientes()

--- a/scripts/crear_bd.sql
+++ b/scripts/crear_bd.sql
@@ -1,0 +1,35 @@
+-- Script de creación de base de datos
+DROP DATABASE IF EXISTS alquiler_vehiculos;
+CREATE DATABASE alquiler_vehiculos CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE alquiler_vehiculos;
+
+-- Tabla de tipos de empleado
+CREATE TABLE tipo_empleado (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(50) NOT NULL UNIQUE,
+    descripcion TEXT
+) ENGINE=InnoDB;
+
+-- Tabla de clientes
+CREATE TABLE clientes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL,
+    documento VARCHAR(20) NOT NULL,
+    telefono VARCHAR(20),
+    direccion VARCHAR(255),
+    correo VARCHAR(100) NOT NULL UNIQUE,
+    contrasena CHAR(64) NOT NULL
+) ENGINE=InnoDB;
+
+-- Tabla de empleados
+CREATE TABLE empleados (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL,
+    documento VARCHAR(20) NOT NULL,
+    telefono VARCHAR(20),
+    direccion VARCHAR(255),
+    correo VARCHAR(100) NOT NULL UNIQUE,
+    contrasena CHAR(64) NOT NULL,
+    tipo_empleado_id INT NOT NULL,
+    FOREIGN KEY (tipo_empleado_id) REFERENCES tipo_empleado(id)
+) ENGINE=InnoDB;

--- a/scripts/poblar_bd.sql
+++ b/scripts/poblar_bd.sql
@@ -1,0 +1,19 @@
+USE alquiler_vehiculos;
+
+-- Tipos de empleado
+INSERT INTO tipo_empleado (nombre, descripcion) VALUES
+    ('empleado', 'Empleado regular'),
+    ('gerente', 'Gerente de sucursal'),
+    ('admin', 'Administrador del sistema');
+
+-- Clientes con correos únicos
+INSERT INTO clientes (nombre, documento, telefono, direccion, correo, contrasena) VALUES
+    ('Ana García', '1010', '3000000001', 'Calle 1', 'cliente1@correo.com', SHA2('cliente123',256)),
+    ('Luis Pérez', '2020', '3000000002', 'Calle 2', 'cliente2@correo.com', SHA2('cliente123',256)),
+    ('María Rodríguez', '3030', '3000000003', 'Calle 3', 'cliente3@correo.com', SHA2('cliente123',256));
+
+-- Empleados de diferentes tipos
+INSERT INTO empleados (nombre, documento, telefono, direccion, correo, contrasena, tipo_empleado_id) VALUES
+    ('Carlos Gómez', '4040', '3100000001', 'Cra 1', 'empleado1@empresa.com', SHA2('empleado123',256), 1),
+    ('Laura Méndez', '5050', '3100000002', 'Cra 2', 'gerente1@empresa.com', SHA2('gerente123',256), 2),
+    ('Administrador', '6060', '3100000003', 'Cra 3', 'admin@admin.com', SHA2('admin123',256), 3);


### PR DESCRIPTION
## Summary
- initialize DB creation script with new tables and unique emails
- populate DB with hashed passwords for clients and employees
- implement MySQL connection handler with failover and pending queue

## Testing
- `python3 -m py_compile conexion/conexion.py`

------
https://chatgpt.com/codex/tasks/task_e_685436b0df2c832b9aaceb75784e22cb