### PR TITLE
Fix pending queue sync with wrong table name

### DIFF
--- a/tests/test_sync_fix.py
+++ b/tests/test_sync_fix.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import MagicMock
+from mysql.connector import Error
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from conexion.conexion import ConexionBD
+
+class SyncFixTest(unittest.TestCase):
+    def setUp(self):
+        self.db = ConexionBD.__new__(ConexionBD)
+        self.db.conn = MagicMock()
+        self.db.conn.is_connected.return_value = True
+        self.db.pendientes = []
+        self.db.queue_file = '/tmp/pendientes_test.json'
+
+    def test_fix_clientes_query(self):
+        cursor = MagicMock()
+        self.db.conn.cursor.return_value = cursor
+        err = Error(msg="1146 (42S02): Table 'alquiler_vehiculos.clientes' doesn't exist")
+        cursor.execute.side_effect = [err, None]
+        self.db.pendientes = [{
+            'query': 'INSERT INTO clientes (nombre) VALUES (%s)',
+            'params': ('Ana',)
+        }]
+        self.db._sincronizar()
+        self.assertEqual(cursor.execute.call_args_list[1][0][0],
+                         'INSERT INTO cliente (nombre) VALUES (%s)')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle operations that reference `clientes` table in `_sincronizar`
- add unit test for the automatic correction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545d067f20832b8ea9dd925e92a113