### PR TITLE
Fix unread result error in synchronization

### DIFF
--- a/conexion/conexion.py
+++ b/conexion/conexion.py
@@ -98,8 +98,11 @@ class ConexionBD:
             try:
                 cur = self.conn.cursor()
                 cur.execute(op['query'], op['params'])
-                if not op['query'].strip().lower().startswith('select'):
+                if op['query'].strip().lower().startswith('select'):
+                    cur.fetchall()
+                else:
                     self.conn.commit()
+                cur.close()
             except Error as e:
                 logging.error('Error al sincronizar: %s', e)
                 if (
@@ -110,8 +113,11 @@ class ConexionBD:
                     logging.info('Reintentando con tabla: %s', corregida)
                     try:
                         cur.execute(corregida, op['params'])
-                        if not corregida.strip().lower().startswith('select'):
+                        if corregida.strip().lower().startswith('select'):
+                            cur.fetchall()
+                        else:
                             self.conn.commit()
+                        cur.close()
                         continue
                     except Error as e2:  # pragma: no cover - depende de MySQL
                         logging.error('Error tras corregir: %s', e2)

--- a/tests/test_sync_fix.py
+++ b/tests/test_sync_fix.py
@@ -29,5 +29,18 @@ class SyncFixTest(unittest.TestCase):
         self.assertEqual(cursor.execute.call_args_list[1][0][0],
                          'INSERT INTO cliente (nombre) VALUES (%s)')
 
+    def test_fetch_select_results(self):
+        cursor = MagicMock()
+        self.db.conn.cursor.return_value = cursor
+        cursor.execute.side_effect = [None]
+        cursor.fetchall.return_value = [(1,)]
+        self.db.pendientes = [{
+            'query': 'SELECT * FROM cliente',
+            'params': None,
+        }]
+        self.db._sincronizar()
+        cursor.fetchall.assert_called_once()
+        cursor.close.assert_called_once()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- properly consume SELECT results in `_sincronizar`
- ensure the cursor is closed for each operation
- add regression test for SELECT handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68545f2514dc832b8de6731096db558f