### PR TITLE
Fix empleado table retry logic

### DIFF
--- a/conexion/conexion.py
+++ b/conexion/conexion.py
@@ -103,34 +103,20 @@ class ConexionBD:
                 else:
                     self.conn.commit()
                 cur.close()
-            except Error as c:
-                logging.error('Error al sincronizar: %s', c)
-                if (
-                    "clientes" in op['query'].lower()
-                    and "doesn't exist" in str(c)
-                ):
-                    corregida = op['query'].replace('clientes', 'cliente')
-                    logging.info('Reintentando con tabla: %s', corregida)
-                    try:
-                        cur.execute(corregida, op['params'])
-                        if corregida.strip().lower().startswith('select'):
-                            cur.fetchall()
-                        else:
-                            self.conn.commit()
-                        cur.close()
-                        continue
-                    except Error as c2:  # pragma: no cover - depende de MySQL
-                        logging.error('Error tras corregir: %s', c2)
-                        op['query'] = corregida
-                self.pendientes.insert(0, op)
-                break
             except Error as e:
                 logging.error('Error al sincronizar: %s', e)
+                corregida = None
                 if (
+                    "clientes" in op['query'].lower()
+                    and "doesn't exist" in str(e)
+                ):
+                    corregida = op['query'].replace('clientes', 'cliente')
+                elif (
                     "empleados" in op['query'].lower()
                     and "doesn't exist" in str(e)
                 ):
                     corregida = op['query'].replace('empleados', 'empleado')
+                if corregida:
                     logging.info('Reintentando con tabla: %s', corregida)
                     try:
                         cur.execute(corregida, op['params'])


### PR DESCRIPTION
## Summary
- streamline `_sincronizar` retry logic
- support correcting `empleados` table name when syncing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685461e1d658832bbfd3e5a37a95f145