### PR TITLE
Fix role matching on login

### DIFF
--- a/interfaces/login.py
+++ b/interfaces/login.py
@@ -31,18 +31,23 @@ class LoginApp(tk.Tk):
         if not rol:
             messagebox.showerror('Error', 'Credenciales inválidas')
             return
-        self.destroy()
+
+        rol = rol.strip().lower()
         if rol == 'cliente':
             from interfaces.cliente import ClienteApp
+            self.destroy()
             ClienteApp().mainloop()
         elif rol == 'empleado':
             from interfaces.empleado import EmpleadoApp
+            self.destroy()
             EmpleadoApp().mainloop()
         elif rol == 'gerente':
             from interfaces.gerente import GerenteApp
+            self.destroy()
             GerenteApp().mainloop()
         elif rol == 'admin':
             from interfaces.admin import AdminApp
+            self.destroy()
             AdminApp().mainloop()
         else:
             messagebox.showerror('Error', 'Rol desconocido')

--- a/logica/auth.py
+++ b/logica/auth.py
@@ -22,8 +22,11 @@ class Autenticador:
         )
         hashed = sha256_hash(password)
         if self.conexion.ejecutar(consulta_cliente, (correo, hashed)):
-            return 'cliente'
+            return "cliente"
+
         resultado = self.conexion.ejecutar(consulta_empleado, (correo, hashed))
         if resultado:
-            return resultado[0][0]
+            rol = str(resultado[0][0]).strip().lower()
+            return rol
+
         return None


### PR DESCRIPTION
## Summary
- normalize role names returned from DB
- keep login window open if role is not recognized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854658218d8832bb00494d6eb3b6388