### PR TITLE
Improve employee role handling

### DIFF
--- a/interfaces/login.py
+++ b/interfaces/login.py
@@ -20,6 +20,11 @@ class LoginApp(tk.Tk):
             'administrador': 'admin',
             'gerete': 'gerente',
             'empleadao': 'empleado',
+            'ventas': 'empleado',
+            'mantenimiento': 'empleado',
+            'operaciones': 'empleado',
+            'conductor': 'empleado',
+            'atencion al cliente': 'empleado',
         }
         return mapping.get(rol, rol)
 

--- a/scripts/poblar_bd.sql
+++ b/scripts/poblar_bd.sql
@@ -31,7 +31,13 @@ INSERT INTO Tipo_empleado (nombre, descripcion, permisos) VALUES
 ('Ventas', 'Empleados del área de ventas',
   '["crear_reserva","editar_reserva","ver_reservas","crear_alquiler"]'),
 ('Mantenimiento', 'Personal encargado del mantenimiento',
-  '["ver_mantenimientos","crear_mantenimiento","editar_mantenimiento"]');
+  '["ver_mantenimientos","crear_mantenimiento","editar_mantenimiento"]'),
+('Atencion al Cliente', 'Personal de servicio al cliente',
+  '["atender_clientes","ver_reservas"]'),
+('Operaciones', 'Jefes y personal de operaciones',
+  '["gestionar_operaciones"]'),
+('Conductor', 'Conductores de vehículos',
+  '["conducir_vehiculos"]');
 
 
 INSERT   INTO Codigo_postal (id_codigo_postal, pais, departamento, ciudad)


### PR DESCRIPTION
## Summary
- normalize "ventas", "mantenimiento" and other roles to generic `empleado`
- add more employee role types in seed script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546bb4625c832b9f64560fca86b273