### PR TITLE
Improve role interfaces and share DB connection

### DIFF
--- a/interfaces/admin.py
+++ b/interfaces/admin.py
@@ -1,13 +1,22 @@
 import tkinter as tk
+from ttkthemes import ThemedTk
+from conexion.conexion import ConexionBD
+from Consulta import MySQLApp
 
 
 class AdminApp(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title('Administrador')
-        self.geometry('300x150')
+        self.geometry('320x200')
         tk.Label(self, text='Panel de administrador').pack(pady=10)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=20)
+        tk.Button(self, text='Abrir consultas SQL', command=self._abrir_sql).pack(pady=5)
+        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+
+    def _abrir_sql(self) -> None:
+        root = ThemedTk(theme='arc')
+        MySQLApp(root, ConexionBD())
+        root.mainloop()
 
     def _logout(self) -> None:
         self.destroy()

--- a/interfaces/cliente.py
+++ b/interfaces/cliente.py
@@ -1,13 +1,22 @@
 import tkinter as tk
+from tkinter import messagebox
 
 
 class ClienteApp(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title('Cliente')
-        self.geometry('300x150')
+        self.geometry('320x200')
         tk.Label(self, text='Bienvenido, cliente').pack(pady=10)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=20)
+        tk.Button(self, text='Reservar vehículo', command=self._reservar).pack(pady=5)
+        tk.Button(self, text='Ver historial', command=self._historial).pack(pady=5)
+        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+
+    def _reservar(self) -> None:
+        messagebox.showinfo('Reservar', 'Función de reserva no implementada')
+
+    def _historial(self) -> None:
+        messagebox.showinfo('Historial', 'Función de historial no implementada')
 
     def _logout(self) -> None:
         self.destroy()

--- a/interfaces/empleado.py
+++ b/interfaces/empleado.py
@@ -1,13 +1,22 @@
 import tkinter as tk
+from tkinter import messagebox
 
 
 class EmpleadoApp(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title('Empleado')
-        self.geometry('300x150')
+        self.geometry('320x200')
         tk.Label(self, text='Panel de empleado').pack(pady=10)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=20)
+        tk.Button(self, text='Registrar alquiler', command=self._registrar).pack(pady=5)
+        tk.Button(self, text='Gestionar vehículos', command=self._vehiculos).pack(pady=5)
+        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+
+    def _registrar(self) -> None:
+        messagebox.showinfo('Registrar', 'Función no implementada')
+
+    def _vehiculos(self) -> None:
+        messagebox.showinfo('Vehículos', 'Función no implementada')
 
     def _logout(self) -> None:
         self.destroy()

--- a/interfaces/gerente.py
+++ b/interfaces/gerente.py
@@ -1,13 +1,22 @@
 import tkinter as tk
+from tkinter import messagebox
 
 
 class GerenteApp(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title('Gerente')
-        self.geometry('300x150')
+        self.geometry('320x200')
         tk.Label(self, text='Panel de gerente').pack(pady=10)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=20)
+        tk.Button(self, text='Ver reportes', command=self._reportes).pack(pady=5)
+        tk.Button(self, text='Gestionar empleados', command=self._empleados).pack(pady=5)
+        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+
+    def _reportes(self) -> None:
+        messagebox.showinfo('Reportes', 'Función no implementada')
+
+    def _empleados(self) -> None:
+        messagebox.showinfo('Empleados', 'Función no implementada')
 
     def _logout(self) -> None:
         self.destroy()

--- a/interfaces/login.py
+++ b/interfaces/login.py
@@ -62,9 +62,13 @@ class LoginApp(tk.Tk):
             self.destroy()
             GerenteApp().mainloop()
         elif rol == 'admin':
-            from interfaces.admin import AdminApp
+            from Consulta import MySQLApp
+            from ttkthemes import ThemedTk
+            from conexion.conexion import ConexionBD
             self.destroy()
-            AdminApp().mainloop()
+            root = ThemedTk(theme='arc')
+            MySQLApp(root, ConexionBD())
+            root.mainloop()
         else:
             messagebox.showerror('Error', 'Rol desconocido')
 


### PR DESCRIPTION
## Summary
- add `ejecutar_con_columnas` to connection helper
- use the shared connection in `Consulta.py`
- launch the SQL console when an admin logs in
- enhance each role interface with basic options

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_68546eba2a10832bb8f95fd6630e7eb2