### PR TITLE
Add console menus and auth logic

### DIFF
--- a/Consulta.py
+++ b/Consulta.py
@@ -313,7 +313,42 @@ class MySQLApp:
 
 
 # ========== Ejecutar la app ==========
-if __name__ == "__main__":
+def run_gui() -> None:
+    """Lanzar la interfaz gráfica de consultas."""
     root = ThemedTk(theme="arc")
     app = MySQLApp(root, ConexionBD())
     root.mainloop()
+
+
+def main() -> None:
+    """Punto de entrada en consola con autenticación por roles."""
+    from getpass import getpass
+
+    from auth import login
+    from cliente import menu_cliente
+    from empleado import menu_empleado
+    from gerente import menu_gerente
+
+    conexion = ConexionBD()
+    print("Sistema de Alquiler de Vehículos")
+    for _ in range(3):
+        correo = input("Correo: ").strip()
+        password = getpass("Contraseña: ")
+        rol = login(conexion, correo, password)
+        if rol:
+            break
+        print("Credenciales inválidas. Intente nuevamente.\n")
+    else:
+        print("Demasiados intentos fallidos")
+        return
+
+    if rol == "cliente":
+        menu_cliente(conexion, correo)
+    elif rol == "empleado":
+        menu_empleado(conexion, correo)
+    else:  # gerente o admin
+        menu_gerente(conexion, correo, es_admin=(rol == "admin"))
+
+
+if __name__ == "__main__":
+    main()

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from conexion.conexion import ConexionBD
+from utils.hash_utils import sha256_hash
+
+
+def login(conexion: ConexionBD, correo: str, password: str) -> Optional[str]:
+    """Verify credentials and return the user role if valid."""
+    hashed = sha256_hash(password)
+    q_cliente = (
+        "SELECT 'cliente' FROM cliente WHERE correo=%s AND contrasena=%s"
+    )
+    q_empleado = (
+        "SELECT te.nombre FROM empleado e "
+        "JOIN tipo_empleado te ON e.id_tipo_empleado=te.id_tipo_empleado "
+        "WHERE e.correo=%s AND e.contrasena=%s"
+    )
+    if conexion.ejecutar(q_cliente, (correo, hashed)):
+        return 'cliente'
+    res = conexion.ejecutar(q_empleado, (correo, hashed))
+    if res:
+        rol = str(res[0][0]).strip().lower()
+        if correo.lower() == 'admin@admin.com':
+            return 'admin'
+        return rol
+    return None

--- a/cliente.py
+++ b/cliente.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from conexion.conexion import ConexionBD
+
+
+def menu_cliente(conexion: ConexionBD, correo: str) -> None:
+    """Loop de menú para clientes."""
+    while True:
+        print("\n--- Menú Cliente ---")
+        print("1. Ver vehículos disponibles")
+        print("2. Realizar una reserva")
+        print("3. Cancelar/modificar reservas")
+        print("4. Ver historial de alquileres")
+        print("5. Actualizar mis datos")
+        print("6. Ver tarifas/promociones")
+        print("7. Ver sucursales")
+        print("0. Salir")
+        opcion = input("Seleccione una opción: ").strip()
+        if opcion == "1":
+            ver_vehiculos_disponibles(conexion)
+        elif opcion == "2":
+            realizar_reserva(conexion, correo)
+        elif opcion == "3":
+            cancelar_reserva(conexion, correo)
+        elif opcion == "4":
+            ver_historial(conexion, correo)
+        elif opcion == "5":
+            actualizar_datos(conexion, correo)
+        elif opcion == "6":
+            ver_tarifas(conexion)
+        elif opcion == "7":
+            ver_sucursales(conexion)
+        elif opcion == "0":
+            break
+        else:
+            print("Opción inválida")
+
+
+def ver_vehiculos_disponibles(conexion: ConexionBD) -> None:
+    try:
+        filas = conexion.ejecutar(
+            "SELECT placa, modelo FROM Vehiculo LIMIT 10"
+        )
+        for placa, modelo in filas:
+            print(f"Placa: {placa} - Modelo: {modelo}")
+    except Exception as exc:  # pragma: no cover - depende de la BD
+        print("Error obteniendo vehículos:", exc)
+
+
+def realizar_reserva(conexion: ConexionBD, correo: str) -> None:
+    print("Función de reserva no implementada")
+
+
+def cancelar_reserva(conexion: ConexionBD, correo: str) -> None:
+    print("Función de cancelación/modificación no implementada")
+
+
+def ver_historial(conexion: ConexionBD, correo: str) -> None:
+    print("Función de historial no implementada")
+
+
+def actualizar_datos(conexion: ConexionBD, correo: str) -> None:
+    print("Función de actualización de datos no implementada")
+
+
+def ver_tarifas(conexion: ConexionBD) -> None:
+    try:
+        filas = conexion.ejecutar("SELECT descripcion, valor FROM Descuento_alquiler")
+        if not filas:
+            print("No hay tarifas o promociones registradas")
+        for desc, valor in filas:
+            print(f"{desc}: {valor}")
+    except Exception as exc:  # pragma: no cover - depende de la BD
+        print("Error consultando tarifas:", exc)
+
+
+def ver_sucursales(conexion: ConexionBD) -> None:
+    print("Función de consulta de sucursales no implementada")

--- a/empleado.py
+++ b/empleado.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from conexion.conexion import ConexionBD
+
+
+def menu_empleado(conexion: ConexionBD, correo: str) -> None:
+    while True:
+        print("\n--- Menú Empleado ---")
+        print("1. Registrar reserva para cliente")
+        print("2. Confirmar entrega/devolución")
+        print("3. Ver estado de la flota")
+        print("4. Registrar daños/incidentes")
+        print("5. Consultar historial por cliente")
+        print("6. Notificar a clientes")
+        print("7. Ver disponibilidad por sede")
+        print("0. Salir")
+        op = input("Seleccione una opción: ").strip()
+        if op == "1":
+            registrar_reserva(conexion)
+        elif op == "2":
+            confirmar_entrega(conexion)
+        elif op == "3":
+            ver_flota(conexion)
+        elif op == "4":
+            registrar_danio(conexion)
+        elif op == "5":
+            historial_cliente(conexion)
+        elif op == "6":
+            notificar_clientes(conexion)
+        elif op == "7":
+            disponibilidad_sede(conexion)
+        elif op == "0":
+            break
+        else:
+            print("Opción inválida")
+
+
+def registrar_reserva(conexion: ConexionBD) -> None:
+    print("Función de registrar reserva no implementada")
+
+
+def confirmar_entrega(conexion: ConexionBD) -> None:
+    print("Función de confirmación de entrega/devolución no implementada")
+
+
+def ver_flota(conexion: ConexionBD) -> None:
+    print("Función de consulta de flota no implementada")
+
+
+def registrar_danio(conexion: ConexionBD) -> None:
+    print("Función de registro de daños no implementada")
+
+
+def historial_cliente(conexion: ConexionBD) -> None:
+    print("Función de historial por cliente no implementada")
+
+
+def notificar_clientes(conexion: ConexionBD) -> None:
+    print("Función de notificación via Twilio no implementada")
+
+
+def disponibilidad_sede(conexion: ConexionBD) -> None:
+    print("Función de disponibilidad por sede no implementada")

--- a/gerente.py
+++ b/gerente.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from conexion.conexion import ConexionBD
+
+
+def menu_gerente(conexion: ConexionBD, correo: str, es_admin: bool = False) -> None:
+    while True:
+        print("\n--- Menú Gerente ---")
+        print("1. Gestionar empleados")
+        print("2. Ver reportes")
+        print("3. Gestionar inventario de vehículos")
+        print("4. Asignar tareas o roles")
+        print("5. Ver historial de operaciones")
+        print("6. Estadísticas de clientes frecuentes")
+        print("7. Generar informes")
+        print("8. Gestionar notificaciones")
+        print("0. Salir")
+        op = input("Seleccione una opción: ").strip()
+        if op == "1":
+            gestionar_empleados(conexion)
+        elif op == "2":
+            ver_reportes(conexion)
+        elif op == "3":
+            gestionar_inventario(conexion)
+        elif op == "4":
+            asignar_tareas(conexion)
+        elif op == "5":
+            historial_operaciones(conexion)
+        elif op == "6":
+            estadisticas_clientes(conexion)
+        elif op == "7":
+            generar_informes(conexion)
+        elif op == "8":
+            gestionar_notificaciones(conexion)
+        elif op == "0":
+            break
+        else:
+            print("Opción inválida")
+
+
+def gestionar_empleados(conexion: ConexionBD) -> None:
+    print("Función de gestión de empleados no implementada")
+
+
+def ver_reportes(conexion: ConexionBD) -> None:
+    print("Función de reportes no implementada")
+
+
+def gestionar_inventario(conexion: ConexionBD) -> None:
+    print("Función de inventario no implementada")
+
+
+def asignar_tareas(conexion: ConexionBD) -> None:
+    print("Función de asignación de tareas no implementada")
+
+
+def historial_operaciones(conexion: ConexionBD) -> None:
+    print("Función de historial de operaciones no implementada")
+
+
+def estadisticas_clientes(conexion: ConexionBD) -> None:
+    print("Función de estadísticas no implementada")
+
+
+def generar_informes(conexion: ConexionBD) -> None:
+    print("Función de generación de informes no implementada")
+
+
+def gestionar_notificaciones(conexion: ConexionBD) -> None:
+    print("Función de notificaciones no implementada")


### PR DESCRIPTION
## Summary
- add new auth module for console login
- create CLI menus for cliente, empleado and gerente roles
- integrate console entrypoint in `Consulta.py`
- keep GUI launchable via `run_gui`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a0a25d1c832bb1fcceb661fcf091