### PR TITLE
Implement themed login and role panels

### DIFF
--- a/interfaces/admin.py
+++ b/interfaces/admin.py
@@ -1,24 +1,42 @@
+from __future__ import annotations
+
 import tkinter as tk
+from tkinter import ttk
 from ttkthemes import ThemedTk
-from conexion.conexion import ConexionBD
+
 from Consulta import MySQLApp
+from conexion.conexion import ConexionBD
 
 
-class AdminApp(tk.Tk):
+class VentanaAdmin(ThemedTk):
     def __init__(self) -> None:
-        super().__init__()
-        self.title('Administrador')
-        self.geometry('320x200')
-        tk.Label(self, text='Panel de administrador').pack(pady=10)
-        tk.Button(self, text='Abrir consultas SQL', command=self._abrir_sql).pack(pady=5)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+        super().__init__(theme="arc")
+        self.title("🛠️ Panel del Administrador")
+        self.configure(bg="#f4f6f9")
+        self.geometry("340x220")
+        self._configurar_estilo()
+        self._build_ui()
+
+    def _configurar_estilo(self) -> None:
+        estilo = ttk.Style(self)
+        estilo.configure("TButton", font=("Segoe UI", 10, "bold"), padding=6)
+        estilo.configure("TLabel", font=("Segoe UI", 11))
+
+    def _build_ui(self) -> None:
+        marco = ttk.Frame(self, padding=20)
+        marco.pack(expand=True)
+
+        ttk.Label(marco, text="🛠️ Panel del Administrador", font=("Segoe UI", 14, "bold")).pack(pady=(0, 15))
+        ttk.Button(marco, text="Abrir consultas SQL", command=self._abrir_sql).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Cerrar sesión", command=self._logout).pack(fill="x", pady=(15, 0))
 
     def _abrir_sql(self) -> None:
-        root = ThemedTk(theme='arc')
+        root = ThemedTk(theme="arc")
         MySQLApp(root, ConexionBD())
         root.mainloop()
 
     def _logout(self) -> None:
         self.destroy()
-        from interfaces.login import LoginApp
-        LoginApp().mainloop()
+        from interfaces.login import VentanaLogin
+
+        VentanaLogin().mainloop()

--- a/interfaces/cliente.py
+++ b/interfaces/cliente.py
@@ -1,67 +1,70 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import messagebox, ttk
+from ttkthemes import ThemedTk
 
 from conexion.conexion import ConexionBD
 
 
-class ClienteApp(tk.Tk):
+class VentanaCliente(ThemedTk):
     def __init__(self) -> None:
-        super().__init__()
-        self.title('Cliente')
-        self.geometry('320x250')
+        super().__init__(theme="arc")
+        self.title("👤 Panel del Cliente")
+        self.configure(bg="#f4f6f9")
+        self.geometry("360x300")
         self.conexion = ConexionBD()
+        self._configurar_estilo()
+        self._build_ui()
 
-        tk.Label(self, text='Bienvenido, cliente').pack(pady=10)
-        tk.Button(self, text='Reservar vehículo', command=self._reservar).pack(pady=5)
-        tk.Button(self, text='Ver historial', command=self._historial).pack(pady=5)
-        tk.Button(self, text='Vehículos disponibles', command=self._ver_vehiculos).pack(pady=5)
-        tk.Button(self, text='Tarifas/promociones', command=self._ver_tarifas).pack(pady=5)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+    def _configurar_estilo(self) -> None:
+        estilo = ttk.Style(self)
+        estilo.configure("TButton", font=("Segoe UI", 10, "bold"), padding=6)
+        estilo.configure("TLabel", font=("Segoe UI", 11))
+
+    def _build_ui(self) -> None:
+        marco = ttk.Frame(self, padding=20)
+        marco.pack(expand=True)
+
+        ttk.Label(marco, text="👤 Panel del Cliente", font=("Segoe UI", 14, "bold")).pack(pady=(0, 15))
+        ttk.Button(marco, text="Ver Reservas", command=self._reservar).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Vehículos disponibles", command=self._ver_vehiculos).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Tarifas/promociones", command=self._ver_tarifas).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Cerrar sesión", command=self._logout).pack(fill="x", pady=(15, 0))
 
     def _reservar(self) -> None:
-        messagebox.showinfo('Reservar', 'Función de reserva no implementada')
-
-    def _historial(self) -> None:
-        messagebox.showinfo('Historial', 'Función de historial no implementada')
+        messagebox.showinfo("Reservas", "Función de reserva no implementada")
 
     def _ver_vehiculos(self) -> None:
         try:
-            filas = self.conexion.ejecutar(
-                'SELECT placa, modelo FROM Vehiculo LIMIT 10'
-            )
+            filas = self.conexion.ejecutar("SELECT placa, modelo FROM Vehiculo LIMIT 10")
         except Exception as exc:
-            messagebox.showerror('Error', f'No se pudieron obtener los vehículos:\n{exc}')
+            messagebox.showerror("Error", f"No se pudieron obtener los vehículos:\n{exc}")
             return
-
-        self._mostrar_resultados('Vehículos disponibles', ['Placa', 'Modelo'], filas)
+        self._mostrar_resultados("Vehículos disponibles", ["Placa", "Modelo"], filas)
 
     def _ver_tarifas(self) -> None:
         try:
-            filas = self.conexion.ejecutar(
-                'SELECT descripcion, valor FROM Descuento_alquiler'
-            )
+            filas = self.conexion.ejecutar("SELECT descripcion, valor FROM Descuento_alquiler")
         except Exception as exc:
-            messagebox.showerror('Error', f'No se pudieron obtener las tarifas:\n{exc}')
+            messagebox.showerror("Error", f"No se pudieron obtener las tarifas:\n{exc}")
             return
-
-        self._mostrar_resultados('Tarifas y promociones', ['Descripción', 'Valor'], filas)
+        self._mostrar_resultados("Tarifas y promociones", ["Descripción", "Valor"], filas)
 
     def _mostrar_resultados(self, titulo: str, columnas: list[str], filas: list[tuple]) -> None:
         ventana = tk.Toplevel(self)
         ventana.title(titulo)
-        ventana.geometry('360x240')
-
-        tree = ttk.Treeview(ventana, columns=columnas, show='headings')
+        ventana.configure(bg="#f4f6f9")
+        tree = ttk.Treeview(ventana, columns=columnas, show="headings")
         for col in columnas:
             tree.heading(col, text=col)
-            tree.column(col, anchor='center', width=150)
-
+            tree.column(col, anchor="center", width=150)
         for fila in filas:
-            tree.insert('', tk.END, values=fila)
-
-        tree.pack(expand=True, fill='both', padx=10, pady=10)
+            tree.insert("", "end", values=fila)
+        tree.pack(expand=True, fill="both", padx=10, pady=10)
 
     def _logout(self) -> None:
         self.destroy()
-        from interfaces.login import LoginApp
-        LoginApp().mainloop()
+        from interfaces.login import VentanaLogin
+
+        VentanaLogin().mainloop()

--- a/interfaces/empleado.py
+++ b/interfaces/empleado.py
@@ -1,24 +1,41 @@
+from __future__ import annotations
+
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
+from ttkthemes import ThemedTk
 
 
-class EmpleadoApp(tk.Tk):
+class VentanaEmpleado(ThemedTk):
     def __init__(self) -> None:
-        super().__init__()
-        self.title('Empleado')
-        self.geometry('320x200')
-        tk.Label(self, text='Panel de empleado').pack(pady=10)
-        tk.Button(self, text='Registrar alquiler', command=self._registrar).pack(pady=5)
-        tk.Button(self, text='Gestionar vehículos', command=self._vehiculos).pack(pady=5)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+        super().__init__(theme="arc")
+        self.title("🧑‍🔧 Panel del Empleado")
+        self.configure(bg="#f4f6f9")
+        self.geometry("340x260")
+        self._configurar_estilo()
+        self._build_ui()
+
+    def _configurar_estilo(self) -> None:
+        estilo = ttk.Style(self)
+        estilo.configure("TButton", font=("Segoe UI", 10, "bold"), padding=6)
+        estilo.configure("TLabel", font=("Segoe UI", 11))
+
+    def _build_ui(self) -> None:
+        marco = ttk.Frame(self, padding=20)
+        marco.pack(expand=True)
+
+        ttk.Label(marco, text="🧑‍🔧 Panel del Empleado", font=("Segoe UI", 14, "bold")).pack(pady=(0, 15))
+        ttk.Button(marco, text="Registrar alquiler", command=self._registrar).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Gestionar Vehículos", command=self._vehiculos).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Cerrar sesión", command=self._logout).pack(fill="x", pady=(15, 0))
 
     def _registrar(self) -> None:
-        messagebox.showinfo('Registrar', 'Función no implementada')
+        messagebox.showinfo("Registrar", "Función no implementada")
 
     def _vehiculos(self) -> None:
-        messagebox.showinfo('Vehículos', 'Función no implementada')
+        messagebox.showinfo("Vehículos", "Función no implementada")
 
     def _logout(self) -> None:
         self.destroy()
-        from interfaces.login import LoginApp
-        LoginApp().mainloop()
+        from interfaces.login import VentanaLogin
+
+        VentanaLogin().mainloop()

--- a/interfaces/gerente.py
+++ b/interfaces/gerente.py
@@ -1,24 +1,41 @@
+from __future__ import annotations
+
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
+from ttkthemes import ThemedTk
 
 
-class GerenteApp(tk.Tk):
+class VentanaGerente(ThemedTk):
     def __init__(self) -> None:
-        super().__init__()
-        self.title('Gerente')
-        self.geometry('320x200')
-        tk.Label(self, text='Panel de gerente').pack(pady=10)
-        tk.Button(self, text='Ver reportes', command=self._reportes).pack(pady=5)
-        tk.Button(self, text='Gestionar empleados', command=self._empleados).pack(pady=5)
-        tk.Button(self, text='Cerrar sesión', command=self._logout).pack(pady=10)
+        super().__init__(theme="arc")
+        self.title("👔 Panel del Gerente")
+        self.configure(bg="#f4f6f9")
+        self.geometry("340x260")
+        self._configurar_estilo()
+        self._build_ui()
+
+    def _configurar_estilo(self) -> None:
+        estilo = ttk.Style(self)
+        estilo.configure("TButton", font=("Segoe UI", 10, "bold"), padding=6)
+        estilo.configure("TLabel", font=("Segoe UI", 11))
+
+    def _build_ui(self) -> None:
+        marco = ttk.Frame(self, padding=20)
+        marco.pack(expand=True)
+
+        ttk.Label(marco, text="👔 Panel del Gerente", font=("Segoe UI", 14, "bold")).pack(pady=(0, 15))
+        ttk.Button(marco, text="Reportes", command=self._reportes).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Gestionar empleados", command=self._empleados).pack(fill="x", pady=5)
+        ttk.Button(marco, text="Cerrar sesión", command=self._logout).pack(fill="x", pady=(15, 0))
 
     def _reportes(self) -> None:
-        messagebox.showinfo('Reportes', 'Función no implementada')
+        messagebox.showinfo("Reportes", "Función no implementada")
 
     def _empleados(self) -> None:
-        messagebox.showinfo('Empleados', 'Función no implementada')
+        messagebox.showinfo("Empleados", "Función no implementada")
 
     def _logout(self) -> None:
         self.destroy()
-        from interfaces.login import LoginApp
-        LoginApp().mainloop()
+        from interfaces.login import VentanaLogin
+
+        VentanaLogin().mainloop()

--- a/interfaces/login.py
+++ b/interfaces/login.py
@@ -1,77 +1,103 @@
-import tkinter as tk
-from tkinter import messagebox
+from __future__ import annotations
+
+from tkinter import messagebox, ttk
+from ttkthemes import ThemedTk
 
 from logica.auth import Autenticador
 
 
-class LoginApp(tk.Tk):
+class VentanaLogin(ThemedTk):
+    """Ventana principal de inicio de sesión."""
+
     def __init__(self) -> None:
-        super().__init__()
-        self.title('Inicio de sesión')
-        self.geometry('300x180')
+        super().__init__(theme="arc")
+        self.title("🔐 Iniciar Sesión")
+        self.configure(bg="#f4f6f9")
+        self.geometry("320x260")
         self.autenticador = Autenticador()
+        self._configurar_estilo()
         self._build_ui()
+
+    def _configurar_estilo(self) -> None:
+        estilo = ttk.Style(self)
+        estilo.configure("TLabel", font=("Segoe UI", 11))
+        estilo.configure("TButton", font=("Segoe UI", 10, "bold"), padding=6)
 
     @staticmethod
     def _normalizar_rol(rol: str) -> str:
         """Mapear variantes comunes de nombres de rol al valor esperado."""
         rol = rol.strip().lower()
         mapping = {
-            'administrador': 'admin',
-            'gerete': 'gerente',
-            'empleadao': 'empleado',
-            'ventas': 'empleado',
-            'mantenimiento': 'empleado',
-            'operaciones': 'empleado',
-            'conductor': 'empleado',
-            'atencion al cliente': 'empleado',
+            "administrador": "admin",
+            "gerete": "gerente",
+            "empleadao": "empleado",
+            "ventas": "empleado",
+            "mantenimiento": "empleado",
+            "operaciones": "empleado",
+            "conductor": "empleado",
+            "atencion al cliente": "empleado",
         }
         return mapping.get(rol, rol)
 
     def _build_ui(self) -> None:
-        tk.Label(self, text='Correo:').pack(pady=5)
-        self.entry_correo = tk.Entry(self)
-        self.entry_correo.pack(fill='x', padx=20)
+        marco = ttk.Frame(self, padding=20)
+        marco.pack(expand=True)
 
-        tk.Label(self, text='Contraseña:').pack(pady=5)
-        self.entry_pass = tk.Entry(self, show='*')
-        self.entry_pass.pack(fill='x', padx=20)
+        ttk.Label(
+            marco,
+            text="🔐 Iniciar Sesión",
+            font=("Segoe UI", 16, "bold"),
+        ).pack(pady=(0, 15))
 
-        tk.Button(self, text='Ingresar', command=self._ingresar).pack(pady=10)
-        tk.Button(self, text='Crear cliente', command=self._abrir_registro).pack(pady=5)
+        ttk.Label(marco, text="Correo:").pack(anchor="w")
+        self.entry_correo = ttk.Entry(marco)
+        self.entry_correo.pack(fill="x", pady=5)
+
+        ttk.Label(marco, text="Contraseña:").pack(anchor="w")
+        self.entry_pass = ttk.Entry(marco, show="*")
+        self.entry_pass.pack(fill="x", pady=5)
+
+        ttk.Button(marco, text="🚪 Iniciar", command=self._ingresar).pack(pady=10, fill="x")
+
+        enlace = ttk.Label(
+            marco,
+            text="🆕 Crear cuenta de cliente",
+            foreground="blue",
+            cursor="hand2",
+        )
+        enlace.pack()
+        enlace.bind("<Button-1>", lambda _e: self._abrir_registro())
 
     def _ingresar(self) -> None:
         correo = self.entry_correo.get().strip()
         password = self.entry_pass.get()
         rol = self.autenticador.autenticar(correo, password)
         if not rol:
-            messagebox.showerror('Error', 'Credenciales inválidas')
+            messagebox.showerror("Error", "Credenciales inválidas")
             return
 
         rol = self._normalizar_rol(rol)
-        if rol == 'cliente':
-            from interfaces.cliente import ClienteApp
-            self.destroy()
-            ClienteApp().mainloop()
-        elif rol == 'empleado':
-            from interfaces.empleado import EmpleadoApp
-            self.destroy()
-            EmpleadoApp().mainloop()
-        elif rol == 'gerente':
-            from interfaces.gerente import GerenteApp
-            self.destroy()
-            GerenteApp().mainloop()
-        elif rol == 'admin':
-            from Consulta import MySQLApp
-            from ttkthemes import ThemedTk
-            from conexion.conexion import ConexionBD
-            self.destroy()
-            root = ThemedTk(theme='arc')
-            MySQLApp(root, ConexionBD())
-            root.mainloop()
+        self.destroy()
+        if rol == "cliente":
+            from interfaces.cliente import VentanaCliente
+
+            VentanaCliente().mainloop()
+        elif rol == "empleado":
+            from interfaces.empleado import VentanaEmpleado
+
+            VentanaEmpleado().mainloop()
+        elif rol == "gerente":
+            from interfaces.gerente import VentanaGerente
+
+            VentanaGerente().mainloop()
+        elif rol == "admin":
+            from interfaces.admin import VentanaAdmin
+
+            VentanaAdmin().mainloop()
         else:
-            messagebox.showerror('Error', 'Rol desconocido')
+            messagebox.showerror("Error", "Rol desconocido")
 
     def _abrir_registro(self) -> None:
-        from interfaces.registro_cliente import RegistroClienteApp
-        RegistroClienteApp(self)
+        from interfaces.registro_cliente import VentanaCrearCliente
+
+        VentanaCrearCliente(self)

--- a/interfaces/registro_cliente.py
+++ b/interfaces/registro_cliente.py
@@ -1,75 +1,71 @@
+from __future__ import annotations
+
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 
 from conexion.conexion import ConexionBD
 from utils.hash_utils import sha256_hash
 from utils.validations import validar_correo
 
 
-class RegistroClienteApp(tk.Toplevel):
+class VentanaCrearCliente(tk.Toplevel):
     """Ventana para registrar un nuevo cliente."""
 
     def __init__(self, master: tk.Misc | None = None) -> None:
         super().__init__(master)
-        self.title('Registro de cliente')
-        self.geometry('320x380')
+        self.title("Crear cliente")
+        self.configure(bg="#f4f6f9")
+        self.geometry("340x420")
         self.conexion = ConexionBD()
+        self._configurar_estilo()
         self._build_ui()
 
+    def _configurar_estilo(self) -> None:
+        estilo = ttk.Style(self)
+        estilo.theme_use("arc")
+        estilo.configure("TLabel", font=("Segoe UI", 11))
+        estilo.configure("TButton", font=("Segoe UI", 10, "bold"), padding=6)
+
     def _build_ui(self) -> None:
-        tk.Label(self, text='Nombre:').pack(pady=5)
-        self.entry_nombre = tk.Entry(self)
-        self.entry_nombre.pack(fill='x', padx=20)
+        marco = ttk.Frame(self, padding=20)
+        marco.pack(fill="both", expand=True)
 
-        tk.Label(self, text='Documento:').pack(pady=5)
-        self.entry_documento = tk.Entry(self)
-        self.entry_documento.pack(fill='x', padx=20)
+        campos = [
+            ("Nombre:", "nombre"),
+            ("Documento:", "documento"),
+            ("Correo:", "correo"),
+            ("Contraseña:", "pass"),
+        ]
+        self.entradas: dict[str, ttk.Entry] = {}
+        for etiqueta, clave in campos:
+            ttk.Label(marco, text=etiqueta).pack(anchor="w", pady=(0, 2))
+            entry = ttk.Entry(marco, show="*" if clave == "pass" else None)
+            entry.pack(fill="x", pady=5)
+            self.entradas[clave] = entry
 
-        tk.Label(self, text='Tel\u00E9fono:').pack(pady=5)
-        self.entry_telefono = tk.Entry(self)
-        self.entry_telefono.pack(fill='x', padx=20)
-
-        tk.Label(self, text='Direcci\u00F3n:').pack(pady=5)
-        self.entry_direccion = tk.Entry(self)
-        self.entry_direccion.pack(fill='x', padx=20)
-
-        tk.Label(self, text='Correo:').pack(pady=5)
-        self.entry_correo = tk.Entry(self)
-        self.entry_correo.pack(fill='x', padx=20)
-
-        tk.Label(self, text='Contrase\u00F1a:').pack(pady=5)
-        self.entry_pass = tk.Entry(self, show='*')
-        self.entry_pass.pack(fill='x', padx=20)
-
-        tk.Button(self, text='Registrar', command=self._registrar).pack(pady=15)
+        ttk.Button(marco, text="💾 Registrar", command=self._registrar).pack(pady=15)
 
     def _registrar(self) -> None:
-        nombre = self.entry_nombre.get().strip()
-        documento = self.entry_documento.get().strip()
-        telefono = self.entry_telefono.get().strip()
-        direccion = self.entry_direccion.get().strip()
-        correo = self.entry_correo.get().strip()
-        contrasena = self.entry_pass.get()
+        nombre = self.entradas["nombre"].get().strip()
+        documento = self.entradas["documento"].get().strip()
+        correo = self.entradas["correo"].get().strip()
+        contrasena = self.entradas["pass"].get()
 
         if not nombre or not documento or not correo or not contrasena:
-            messagebox.showerror('Error', 'Nombre, documento, correo y contrase\u00F1a son obligatorios')
+            messagebox.showerror("Error", "Todos los campos son obligatorios")
             return
         if not validar_correo(correo):
-            messagebox.showerror('Error', 'Correo no v\u00E1lido')
+            messagebox.showerror("Error", "Correo no válido")
             return
 
         query = (
-            'INSERT INTO cliente '
-            '(nombre, documento, telefono, direccion, correo, contrasena) '
-            'VALUES (%s, %s, %s, %s, %s, %s)'
+            "INSERT INTO cliente (nombre, documento, correo, contrasena) "
+            "VALUES (%s, %s, %s, %s)"
         )
         hashed = sha256_hash(contrasena)
         try:
-            self.conexion.ejecutar(
-                query,
-                (nombre, documento, telefono, direccion, correo, hashed),
-            )
-            messagebox.showinfo('\u00C9xito', 'Cliente creado correctamente')
+            self.conexion.ejecutar(query, (nombre, documento, correo, hashed))
+            messagebox.showinfo("Éxito", "Cliente creado correctamente")
             self.destroy()
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror('Error', f'No se pudo crear el cliente: {exc}')
+            messagebox.showerror("Error", f"No se pudo crear el cliente: {exc}")

--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
 from utils.logger import configurar_logging
-from interfaces.login import LoginApp
+from interfaces.login import VentanaLogin
 
 
 def main() -> None:
     configurar_logging()
-    app = LoginApp()
+    app = VentanaLogin()
     app.mainloop()
 
 


### PR DESCRIPTION
## Summary
- refactor login window as `VentanaLogin` using `ThemedTk`
- add `VentanaCrearCliente` registration form
- create themed panels for each role
- update entry points to use new classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ac287448832b90fc0c0069eb79a0