### PR TITLE
Update reservation input to use datetime ranges

### DIFF
--- a/interfaces/cliente.py
+++ b/interfaces/cliente.py
@@ -38,12 +38,17 @@ class VentanaCliente(ThemedTk):
         ventana.title("Nueva reserva")
         ventana.configure(bg="#f4f6f9")
 
-        ttk.Label(ventana, text="Fecha y hora (YYYY-MM-DD HH:MM):").pack(
-            anchor="w", padx=10, pady=(10, 2)
-        )
-        entry_fecha = ttk.Entry(ventana)
-        entry_fecha.pack(fill="x", padx=10, pady=5)
-        entry_fecha.insert(0, datetime.now().strftime("%Y-%m-%d %H:%M"))
+        ttk.Label(
+            ventana, text="Fecha y hora inicio (YYYY-MM-DD HH:MM):"
+        ).pack(anchor="w", padx=10, pady=(10, 2))
+        entry_inicio = ttk.Entry(ventana)
+        entry_inicio.pack(fill="x", padx=10, pady=5)
+
+        ttk.Label(
+            ventana, text="Fecha y hora fin (YYYY-MM-DD HH:MM):"
+        ).pack(anchor="w", padx=10, pady=(10, 2))
+        entry_fin = ttk.Entry(ventana)
+        entry_fin.pack(fill="x", padx=10, pady=5)
 
         ttk.Label(ventana, text="Abono:").pack(anchor="w", padx=10, pady=(10, 2))
         entry_abono = ttk.Entry(ventana)
@@ -56,11 +61,25 @@ class VentanaCliente(ThemedTk):
         entry_saldo.pack(fill="x", padx=10, pady=5)
 
         def registrar() -> None:
-            fecha = entry_fecha.get().strip()
+            inicio = entry_inicio.get().strip()
+            fin = entry_fin.get().strip()
             abono = entry_abono.get().strip()
             saldo = entry_saldo.get().strip()
-            if not fecha or not abono or not saldo:
+            if not inicio or not fin or not abono or not saldo:
                 messagebox.showerror("Error", "Todos los campos son obligatorios")
+                return
+            try:
+                fecha_ini = datetime.strptime(inicio, "%Y-%m-%d %H:%M")
+                fecha_fin = datetime.strptime(fin, "%Y-%m-%d %H:%M")
+            except ValueError:
+                messagebox.showerror(
+                    "Error", "Formato de fechas incorrecto (YYYY-MM-DD HH:MM)"
+                )
+                return
+            if fecha_fin < fecha_ini:
+                messagebox.showerror(
+                    "Error", "La fecha de fin debe ser posterior a la de inicio"
+                )
                 return
             try:
                 abono_val = float(abono)
@@ -69,14 +88,16 @@ class VentanaCliente(ThemedTk):
                 messagebox.showerror("Error", "Valores num\u00e9ricos inv\u00e1lidos")
                 return
             query = (
-                "INSERT INTO Reserva_alquiler (fecha_hora, abono, saldo_pendiente, id_estado_reserva) "
-                "VALUES (%s, %s, %s, %s)"
+                "INSERT INTO Reserva_alquiler "
+                "(fecha_hora, fecha_hora_inicio, fecha_hora_fin, abono, saldo_pendiente, id_estado_reserva) "
+                "VALUES (NOW(), %s, %s, %s, %s, %s)"
             )
             try:
                 self.conexion.ejecutar(
                     query,
                     (
-                        fecha,
+                        fecha_ini.strftime("%Y-%m-%d %H:%M:%S"),
+                        fecha_fin.strftime("%Y-%m-%d %H:%M:%S"),
                         abono_val,
                         saldo_val,
                         1,  # Estado 'Reservado'

--- a/interfaces/reserva_cliente.py
+++ b/interfaces/reserva_cliente.py
@@ -43,12 +43,12 @@ class VentanaReservaCliente(ThemedTk):
         self.combo_vehiculo.pack(fill="x", pady=5)
         self.combo_vehiculo.bind("<<ComboboxSelected>>", lambda _e: self._calcular_total())
 
-        ttk.Label(marco, text="Fecha inicio (YYYY-MM-DD):").pack(anchor="w")
+        ttk.Label(marco, text="Fecha y hora inicio (YYYY-MM-DD HH:MM):").pack(anchor="w")
         self.entry_inicio = ttk.Entry(marco)
         self.entry_inicio.pack(fill="x", pady=5)
         self.entry_inicio.bind("<FocusOut>", lambda _e: self._calcular_total())
 
-        ttk.Label(marco, text="Fecha fin (YYYY-MM-DD):").pack(anchor="w")
+        ttk.Label(marco, text="Fecha y hora fin (YYYY-MM-DD HH:MM):").pack(anchor="w")
         self.entry_fin = ttk.Entry(marco)
         self.entry_fin.pack(fill="x", pady=5)
         self.entry_fin.bind("<FocusOut>", lambda _e: self._calcular_total())
@@ -134,11 +134,13 @@ class VentanaReservaCliente(ThemedTk):
         self, ini: str, fin: str, mostrar_error: bool = True
     ) -> tuple[datetime, datetime] | None:
         try:
-            fecha_ini = datetime.strptime(ini, "%Y-%m-%d")
-            fecha_fin = datetime.strptime(fin, "%Y-%m-%d")
+            fecha_ini = datetime.strptime(ini, "%Y-%m-%d %H:%M")
+            fecha_fin = datetime.strptime(fin, "%Y-%m-%d %H:%M")
         except ValueError:
             if mostrar_error:
-                messagebox.showerror("Error", "Formato de fechas incorrecto")
+                messagebox.showerror(
+                    "Error", "Formato de fechas incorrecto (YYYY-MM-DD HH:MM)"
+                )
             return None
         if fecha_fin < fecha_ini:
             if mostrar_error:
@@ -198,8 +200,9 @@ class VentanaReservaCliente(ThemedTk):
         restante = total_pago - abono_val
         query_reserva = (
             "INSERT INTO Reserva_alquiler "
-            "(fecha_hora, abono, saldo_pendiente, id_estado_reserva) "
-            "VALUES (%s, %s, %s, %s)"
+            "(fecha_hora, fecha_hora_inicio, fecha_hora_fin, abono, "
+            "saldo_pendiente, id_estado_reserva) "
+            "VALUES (NOW(), %s, %s, %s, %s, %s)"
         )
         query_abono = (
             "INSERT INTO Abono_reserva (valor, fecha_hora, id_reserva, id_medio_pago) "
@@ -210,6 +213,7 @@ class VentanaReservaCliente(ThemedTk):
                 query_reserva,
                 (
                     fecha_ini.strftime("%Y-%m-%d %H:%M:%S"),
+                    fecha_fin.strftime("%Y-%m-%d %H:%M:%S"),
                     abono_val,
                     restante,
                     1,


### PR DESCRIPTION
## Summary
- adjust client reservation UI to request start and end datetimes
- validate datetime format when creating reservations
- store `fecha_hora` automatically and include `fecha_hora_inicio` and
  `fecha_hora_fin` in reservation inserts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d4b83adc832b9ec054a92e2adb51