### PR TITLE
Improve logout cleanup for Tk windows

### DIFF
--- a/interfaces/admin.py
+++ b/interfaces/admin.py
@@ -6,11 +6,14 @@ from ttkthemes import ThemedTk
 
 from Consulta import MySQLApp
 from conexion.conexion import ConexionBD
+from utils import cancel_pending_after, safe_bg_error_handler
 
 
 class VentanaAdmin(ThemedTk):
     def __init__(self) -> None:
         super().__init__(theme="arc")
+        self.report_callback_exception = safe_bg_error_handler
+        self._after_ids: list[str] = []
         self.title("🛠️ Panel del Administrador")
         self.configure(bg="#2a2a2a")
         self.geometry("340x220")
@@ -46,6 +49,8 @@ class VentanaAdmin(ThemedTk):
     def _logout(self) -> None:
         if self.ventana_consulta and self.ventana_consulta.winfo_exists():
             self.ventana_consulta.destroy()
+        cancel_pending_after(self)
+        self.quit()
         self.destroy()
         from interfaces.login import VentanaLogin
 

--- a/interfaces/cliente.py
+++ b/interfaces/cliente.py
@@ -9,6 +9,7 @@ from tkcalendar import Calendar
 import customtkinter as ctk
 
 import logging
+from utils import cancel_pending_after, safe_bg_error_handler
 
 from conexion.conexion import ConexionBD
 from interfaces.componentes.ctk_scrollable_combobox import CTkScrollableComboBox
@@ -76,6 +77,8 @@ class VentanaCliente(ctk.CTk):
 
     def __init__(self, id_cliente: int) -> None:
         super().__init__()
+        self.report_callback_exception = safe_bg_error_handler
+        self._after_ids: list[str] = []
         self.id_cliente = id_cliente
         self.conexion = ConexionBD()
         self.title("\U0001f464 Panel del Cliente")
@@ -610,6 +613,10 @@ class VentanaCliente(ctk.CTk):
 
     # ------------------------------------------------------------------
     def _logout(self) -> None:
+        from utils import cancel_pending_after
+
+        cancel_pending_after(self)
+        self.quit()
         self.destroy()
         from interfaces.login import VentanaLogin
 

--- a/interfaces/empleado.py
+++ b/interfaces/empleado.py
@@ -9,11 +9,14 @@ import logging
 
 from conexion.conexion import ConexionBD
 from interfaces.componentes.ctk_scrollable_combobox import CTkScrollableComboBox
+from utils import cancel_pending_after, safe_bg_error_handler
 
 
 class VentanaEmpleado(ThemedTk):
     def __init__(self) -> None:
         super().__init__(theme="arc")
+        self.report_callback_exception = safe_bg_error_handler
+        self._after_ids: list[str] = []
         self.title("🧑‍🔧 Panel del Empleado")
         self.configure(bg="#2a2a2a")
         self.geometry("340x260")
@@ -66,6 +69,8 @@ class VentanaEmpleado(ThemedTk):
     def _logout(self) -> None:
         for win in list(self._subventanas):
             win.destroy()
+        cancel_pending_after(self)
+        self.quit()
         self.destroy()
         from interfaces.login import VentanaLogin
 

--- a/interfaces/gerente.py
+++ b/interfaces/gerente.py
@@ -5,6 +5,7 @@ from datetime import date
 from tkinter import messagebox, ttk
 
 import customtkinter as ctk
+from utils import cancel_pending_after, safe_bg_error_handler
 
 from conexion.conexion import ConexionBD
 from interfaces.cliente import SimpleDateEntry
@@ -19,6 +20,8 @@ class VentanaGerente(ctk.CTk):
 
     def __init__(self) -> None:
         super().__init__()
+        self.report_callback_exception = safe_bg_error_handler
+        self._after_ids: list[str] = []
         self.conexion = ConexionBD()
         self.title("\U0001f454 Panel del Gerente")
         self.geometry("900x600")
@@ -331,6 +334,8 @@ class VentanaGerente(ctk.CTk):
 
     # ------------------------------------------------------------------
     def _logout(self) -> None:
+        cancel_pending_after(self)
+        self.quit()
         self.destroy()
         from interfaces.login import VentanaLogin
 

--- a/interfaces/login.py
+++ b/interfaces/login.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from tkinter import messagebox
 import customtkinter as ctk
+from utils import cancel_pending_after, safe_bg_error_handler
 
 ctk.set_appearance_mode("dark")  # o "light"
 ctk.set_default_color_theme("blue")
@@ -14,6 +15,8 @@ class VentanaLogin(ctk.CTk):
 
     def __init__(self) -> None:
         super().__init__()
+        self.report_callback_exception = safe_bg_error_handler
+        self._after_ids: list[str] = []
         self.title("🔐 Iniciar Sesión")
         self.geometry("320x260")
         self.configure(fg_color="#2a2a2a")
@@ -79,6 +82,8 @@ class VentanaLogin(ctk.CTk):
             return
 
         rol = self._normalizar_rol(rol)
+        cancel_pending_after(self)
+        self.quit()
         self.destroy()
         if rol == "cliente":
             from interfaces.cliente import VentanaCliente

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,18 @@
+def safe_bg_error_handler(*_args) -> None:
+    """Global handler for exceptions raised in Tk callbacks."""
+    import traceback
+
+    print("Error capturado en bgerror:")
+    traceback.print_exc()
+
+
+def cancel_pending_after(widget) -> None:
+    """Cancel any scheduled callbacks stored in ``widget._after_ids``."""
+    for after_id in getattr(widget, "_after_ids", []):
+        try:
+            widget.after_cancel(after_id)
+        except Exception:
+            pass
+    if hasattr(widget, "_after_ids"):
+        widget._after_ids.clear()
+


### PR DESCRIPTION
## Summary
- cancel pending `after` callbacks in `utils.cancel_pending_after`
- register background error handler with `safe_bg_error_handler`
- ensure `VentanaCliente` cancels callbacks and quits mainloop before destroying
- handle cleanup similarly in `VentanaGerente`, `VentanaEmpleado` and `VentanaAdmin`
- apply handler and quit logic in login window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_685811a22be8832bb0bb6fea681ff75c