### PR TITLE
Centralized error management with CTk notifications

### DIFF
--- a/interfaces/empleado.py
+++ b/interfaces/empleado.py
@@ -9,7 +9,12 @@ import logging
 
 from conexion.conexion import ConexionBD
 from interfaces.componentes.ctk_scrollable_combobox import CTkScrollableComboBox
-from utils import cancel_pending_after, safe_bg_error_handler
+from utils import (
+    cancel_pending_after,
+    safe_bg_error_handler,
+    mostrar_error,
+    mostrar_notificacion,
+)
 
 
 class VentanaEmpleado(ThemedTk):
@@ -115,7 +120,7 @@ class VentanaGestionReservas(tk.Toplevel):
             filas = self.conexion.ejecutar(query)
         except Exception as exc:  # pragma: no cover - conexion errors vary
             logging.error("Error cargando reservas: %s", exc)
-            messagebox.showerror("Error", f"No se pudieron cargar reservas:\n{exc}")
+            mostrar_error(exc)
             filas = []
         self.tree.delete(*self.tree.get_children())
         for fila in filas:
@@ -132,11 +137,11 @@ class VentanaGestionReservas(tk.Toplevel):
                 "UPDATE Reserva_alquiler SET id_estado_reserva=1 WHERE id_reserva=%s",
                 (id_reserva,),
             )
-            messagebox.showinfo("Éxito", "Reserva aprobada")
+            mostrar_notificacion("Éxito", "Reserva aprobada")
             self._cargar()
         except Exception as exc:  # pragma: no cover - conexion errors vary
             logging.error("Error aprobando reserva: %s", exc)
-            messagebox.showerror("Error", f"No se pudo aprobar:\n{exc}")
+            mostrar_error(exc)
 
     def _rechazar(self) -> None:
         item = self.tree.focus()
@@ -149,11 +154,11 @@ class VentanaGestionReservas(tk.Toplevel):
                 "UPDATE Reserva_alquiler SET id_estado_reserva=2 WHERE id_reserva=%s",
                 (id_reserva,),
             )
-            messagebox.showinfo("Éxito", "Reserva cancelada")
+            mostrar_notificacion("Éxito", "Reserva cancelada")
             self._cargar()
         except Exception as exc:  # pragma: no cover - conexion errors vary
             logging.error("Error cancelando reserva: %s", exc)
-            messagebox.showerror("Error", f"No se pudo cancelar:\n{exc}")
+            mostrar_error(exc)
 
     def _abrir_abonos(self) -> None:
         item = self.tree.focus()
@@ -199,7 +204,7 @@ class VentanaAbonos(tk.Toplevel):
             )
         except Exception as exc:  # pragma: no cover - conexion errors vary
             logging.error("Error consultando abonos: %s", exc)
-            messagebox.showerror("Error", f"No se pudieron obtener abonos:\n{exc}")
+            mostrar_error(exc)
             filas = []
         self.tree.delete(*self.tree.get_children())
         for fila in filas:
@@ -222,11 +227,11 @@ class VentanaAbonos(tk.Toplevel):
                 "UPDATE Abono_reserva SET valor=%s WHERE id_abono_reserva=%s",
                 (valor, abono_id),
             )
-            messagebox.showinfo("Éxito", "Abono actualizado")
+            mostrar_notificacion("Éxito", "Abono actualizado")
             self._cargar()
         except Exception as exc:  # pragma: no cover - conexion errors vary
             logging.error("Error actualizando abono: %s", exc)
-            messagebox.showerror("Error", f"No se pudo actualizar:\n{exc}")
+            mostrar_error(exc)
 
 
 class VentanaVehiculos(tk.Toplevel):
@@ -258,7 +263,7 @@ class VentanaVehiculos(tk.Toplevel):
             filas = self.conexion.ejecutar("SELECT placa, modelo FROM Vehiculo")
         except Exception as exc:  # pragma: no cover - conexion errors vary
             logging.error("Error cargando vehículos: %s", exc)
-            messagebox.showerror("Error", f"No se pudieron cargar vehículos:\n{exc}")
+            mostrar_error(exc)
             filas = []
         self.tree.delete(*self.tree.get_children())
         for fila in filas:
@@ -285,11 +290,11 @@ class VentanaVehiculos(tk.Toplevel):
                     "INSERT INTO Vehiculo (placa, modelo) VALUES (%s, %s)",
                     (placa, modelo),
                 )
-                messagebox.showinfo("Éxito", "Vehículo registrado")
+                mostrar_notificacion("Éxito", "Vehículo registrado")
                 top.destroy()
                 self._cargar()
             except Exception as exc:  # pragma: no cover - conexion errors vary
-                messagebox.showerror("Error", f"No se pudo registrar:\n{exc}")
+                mostrar_error(exc)
 
         ttk.Button(top, text="Guardar", command=guardar).grid(row=2, column=0, columnspan=2, pady=10)
 
@@ -303,7 +308,7 @@ class VentanaVehiculos(tk.Toplevel):
             return
         try:
             self.conexion.ejecutar("DELETE FROM Vehiculo WHERE placa=%s", (placa,))
-            messagebox.showinfo("Éxito", "Vehículo eliminado")
+            mostrar_notificacion("Éxito", "Vehículo eliminado")
             self._cargar()
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror("Error", f"No se pudo eliminar:\n{exc}")
+            mostrar_error(exc)

--- a/interfaces/gerente.py
+++ b/interfaces/gerente.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tkinter as tk
 from datetime import date
 from tkinter import messagebox, ttk
+from utils import cancel_pending_after, safe_bg_error_handler, mostrar_error, mostrar_notificacion
 
 import customtkinter as ctk
 from utils import cancel_pending_after, safe_bg_error_handler
@@ -94,9 +95,7 @@ class VentanaGerente(ctk.CTk):
         try:
             filas = self.conexion.ejecutar(query, params)
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror(
-                "Error", f"No se pudieron obtener las reservas:\n{exc}"
-            )
+            mostrar_error(exc)
             filas = []
         self.tree_res.delete(*self.tree_res.get_children())
         for fila in filas:
@@ -129,9 +128,7 @@ class VentanaGerente(ctk.CTk):
         try:
             filas = self.conexion.ejecutar(query)
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror(
-                "Error", f"No se pudieron obtener los alquileres:\n{exc}"
-            )
+            mostrar_error(exc)
             filas = []
         self.tree_alq.delete(*self.tree_alq.get_children())
         for fila in filas:
@@ -229,9 +226,7 @@ class VentanaGerente(ctk.CTk):
                 (desde.strftime("%Y-%m-%d"), hasta.strftime("%Y-%m-%d")),
             )
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror(
-                "Error", f"No se pudieron generar los reportes:\n{exc}"
-            )
+            mostrar_error(exc)
             ingresos, reservas, vehiculos, clientes = 0, 0, [], []
         self.lbl_ingresos.configure(text=f"Ingresos del mes: ${float(ingresos):,.2f}")
         self.lbl_reservas.configure(text=f"Reservas este mes: {reservas}")
@@ -279,9 +274,7 @@ class VentanaGerente(ctk.CTk):
                 "FROM Empleado e JOIN Tipo_empleado te ON e.id_tipo_empleado=te.id_tipo_empleado"
             )
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror(
-                "Error", f"No se pudieron obtener los empleados:\n{exc}"
-            )
+            mostrar_error(exc)
             filas = []
             self.tipo_map = {}
         self.tree_emp.delete(*self.tree_emp.get_children())
@@ -307,10 +300,10 @@ class VentanaGerente(ctk.CTk):
                 "UPDATE Empleado SET id_tipo_empleado=%s WHERE id_empleado=%s",
                 (id_tipo, id_emp),
             )
-            messagebox.showinfo("Éxito", "Tipo actualizado")
+            mostrar_notificacion("Éxito", "Tipo actualizado")
             self._cargar_empleados()
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror("Error", f"No se pudo actualizar:\n{exc}")
+            mostrar_error(exc)
 
     def _eliminar_empleado(self) -> None:
         item = self.tree_emp.focus()
@@ -327,10 +320,10 @@ class VentanaGerente(ctk.CTk):
             self.conexion.ejecutar(
                 "DELETE FROM Empleado WHERE id_empleado=%s", (id_emp,)
             )
-            messagebox.showinfo("Éxito", "Empleado eliminado")
+            mostrar_notificacion("Éxito", "Empleado eliminado")
             self._cargar_empleados()
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror("Error", f"No se pudo eliminar:\n{exc}")
+            mostrar_error(exc)
 
     # ------------------------------------------------------------------
     def _logout(self) -> None:

--- a/interfaces/registro_cliente.py
+++ b/interfaces/registro_cliente.py
@@ -7,6 +7,7 @@ from conexion.conexion import ConexionBD
 from interfaces.componentes.ctk_scrollable_combobox import CTkScrollableComboBox
 from utils.hash_utils import sha256_hash
 from utils.validations import validar_correo
+from utils import mostrar_error, mostrar_notificacion
 
 
 class VentanaCrearCliente(tk.Toplevel):
@@ -66,7 +67,7 @@ class VentanaCrearCliente(tk.Toplevel):
         hashed = sha256_hash(contrasena)
         try:
             self.conexion.ejecutar(query, (nombre, documento, correo, hashed))
-            messagebox.showinfo("Éxito", "Cliente creado correctamente")
+            mostrar_notificacion("Éxito", "Cliente creado correctamente")
             self.destroy()
         except Exception as exc:  # pragma: no cover - conexion errors vary
-            messagebox.showerror("Error", f"No se pudo crear el cliente: {exc}")
+            mostrar_error(exc)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -16,3 +16,12 @@ def cancel_pending_after(widget) -> None:
     if hasattr(widget, "_after_ids"):
         widget._after_ids.clear()
 
+from .errores import mostrar_error, mostrar_notificacion
+
+__all__ = [
+    "safe_bg_error_handler",
+    "cancel_pending_after",
+    "mostrar_error",
+    "mostrar_notificacion",
+]
+

--- a/utils/errores.py
+++ b/utils/errores.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+import tkinter as tk
+from tkinter import messagebox
+import customtkinter as ctk
+
+
+def mostrar_error(error: Exception) -> None:
+    """Log and show an error using a messagebox."""
+    logging.error("%s", error)
+    messagebox.showerror("Error", str(error))
+
+
+def mostrar_notificacion(titulo: str, mensaje: str) -> None:
+    """Display a small centered CTkToplevel with a message."""
+    top = ctk.CTkToplevel()
+    top.title(titulo)
+    top.resizable(False, False)
+    label = ctk.CTkLabel(top, text=mensaje, font=("Segoe UI", 12))
+    label.pack(padx=20, pady=20)
+
+    top.update_idletasks()
+    x = (top.winfo_screenwidth() // 2) - (top.winfo_width() // 2)
+    y = (top.winfo_screenheight() // 2) - (top.winfo_height() // 2)
+    top.geometry(f"+{x}+{y}")
+    top.after(4000, top.destroy)
+    top.grab_set()
+    top.focus_force()


### PR DESCRIPTION
## Summary
- centralize GUI error messages in `utils/errores.py`
- export helper functions from `utils.__init__`
- replace scattered message boxes by `mostrar_error` and `mostrar_notificacion`
- unify notifications in interfaces and Consulta panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_6858150b1ae4832b9df5b9e3c7355160