### PR TITLE
Implement redundant DB manager

### DIFF
--- a/conexion/conexion.py
+++ b/conexion/conexion.py
@@ -33,7 +33,16 @@ class DatabaseExecutionError(Exception):
 class ConexionBD:
     """Manejo de conexión MySQL con failover, cola de operaciones y prueba de conexión."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, active: str = "remote", queue_file: str = "pendientes.json") -> None:
+        """Inicializa la conexión.
+
+        Parameters
+        ----------
+        active:
+            Indica qué base usar inicialmente, ``"remote"`` o ``"local"``.
+        queue_file:
+            Ruta del archivo donde se almacenarán las operaciones pendientes.
+        """
         load_dotenv()
         self.local_conf = {
             'host': os.getenv('DB1_HOST'),
@@ -47,9 +56,9 @@ class ConexionBD:
             'password': os.getenv('DB_PASSWORD'),
             'database': os.getenv('DB_NAME'),
         }
-        self.active = 'remote'
+        self.active = active
         self.conn: MySQLConnection | None = None
-        self.queue_file = 'pendientes.json'
+        self.queue_file = queue_file
         self._cargar_pendientes()
         self.conectar()
 

--- a/redundancia/__init__.py
+++ b/redundancia/__init__.py
@@ -1,1 +1,5 @@
 """Módulos relacionados con tolerancia a fallos y sincronización."""
+
+from .gestor import GestorRedundancia
+
+__all__ = ["GestorRedundancia"]

--- a/redundancia/gestor.py
+++ b/redundancia/gestor.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, List, Tuple, Optional
+
+from conexion.conexion import ConexionBD
+
+
+class GestorRedundancia:
+    """Ejecuta cada operación en la base local y en la remota."""
+
+    def __init__(self) -> None:
+        # Conexión dedicada para cada base
+        self.local = ConexionBD(active="local", queue_file="pendientes_local.json")
+        self.remota = ConexionBD(active="remote", queue_file="pendientes_remota.json")
+
+    def ejecutar(self, query: str, params: Optional[Tuple[Any, ...]] = None) -> List[Tuple[Any, ...]]:
+        """Ejecuta una consulta en ambas bases de datos.
+
+        Devuelve el resultado obtenido de la base remota si está
+        disponible; de lo contrario se devuelve el de la base local.
+        """
+        res_local: List[Tuple[Any, ...]] | None = None
+        res_remota: List[Tuple[Any, ...]] | None = None
+        try:
+            res_local = self.local.ejecutar(query, params)
+        except Exception:
+            # La lógica de ConexionBD ya gestiona el almacenamiento de pendientes
+            pass
+        try:
+            res_remota = self.remota.ejecutar(query, params)
+        except Exception:
+            pass
+
+        return res_remota if res_remota is not None else (res_local or [])


### PR DESCRIPTION
## Summary
- extend `ConexionBD` constructor to accept active DB and queue file
- add new redundancy manager to run queries on local and remote DBs
- expose `GestorRedundancia` in the `redundancia` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_685acda797c8832bb234062f02250899