### PR TITLE
Add standalone client registration

### DIFF
--- a/interfaces/registro_cliente.py
+++ b/interfaces/registro_cliente.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import messagebox, ttk
 
-from conexion.conexion import ConexionBD
 from interfaces.componentes.ctk_scrollable_combobox import CTkScrollableComboBox
-from utils.hash_utils import sha256_hash
-from utils.validations import validar_correo
 from utils import mostrar_error, mostrar_notificacion
+from logica.clientes import crear_cliente, DatosClienteInvalidos
 
 
 class VentanaCrearCliente(tk.Toplevel):
@@ -18,7 +16,6 @@ class VentanaCrearCliente(tk.Toplevel):
         self.title("Crear cliente")
         self.configure(bg="#2a2a2a")
         self.geometry("360x580")
-        self.conexion = ConexionBD()
         self._configurar_estilo()
         self._build_ui()
 
@@ -65,47 +62,22 @@ class VentanaCrearCliente(tk.Toplevel):
         id_tipo_cliente = self.entradas["id_tipo_cliente"].get().strip()
         id_codigo_postal = self.entradas["id_codigo_postal"].get().strip()
 
-        if (
-            not documento
-            or not nombre
-            or not telefono
-            or not direccion
-            or not correo
-            or not contrasena
-            or not id_licencia
-            or not id_tipo_documento
-            or not id_tipo_cliente
-            or not id_codigo_postal
-        ):
-            messagebox.showerror("Error", "Todos los campos son obligatorios")
-            return
-        if not validar_correo(correo):
-            messagebox.showerror("Error", "Correo no válido")
-            return
-        hashed = sha256_hash(contrasena)
-        query = (
-            "INSERT INTO Cliente (documento, nombre, telefono, direccion, correo, "
-            "contrasena, infracciones, id_licencia, id_tipo_documento, "
-            "id_tipo_cliente, id_codigo_postal, id_cuenta) "
-            "VALUES (%s, %s, %s, %s, %s, %s, 0, %s, %s, %s, %s, NULL)"
-        )
         try:
-            self.conexion.ejecutar(
-                query,
-                (
-                    documento,
-                    nombre,
-                    telefono,
-                    direccion,
-                    correo,
-                    hashed,
-                    id_licencia,
-                    id_tipo_documento,
-                    id_tipo_cliente,
-                    id_codigo_postal,
-                ),
+            crear_cliente(
+                documento,
+                nombre,
+                telefono,
+                direccion,
+                correo,
+                contrasena,
+                id_licencia,
+                id_tipo_documento,
+                id_tipo_cliente,
+                id_codigo_postal,
             )
             mostrar_notificacion("Éxito", "Cliente creado correctamente")
             self.destroy()
+        except DatosClienteInvalidos as exc:
+            messagebox.showerror("Error", str(exc))
         except Exception as exc:  # pragma: no cover - conexion errors vary
             mostrar_error(exc)

--- a/logica/clientes.py
+++ b/logica/clientes.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from conexion.conexion import ConexionBD
+from utils.hash_utils import sha256_hash
+from utils.validations import validar_correo
+
+
+class DatosClienteInvalidos(ValueError):
+    """Excepción para datos inválidos del cliente."""
+
+
+def crear_cliente(
+    documento: str,
+    nombre: str,
+    telefono: str,
+    direccion: str,
+    correo: str,
+    contrasena: str,
+    id_licencia: str,
+    id_tipo_documento: str,
+    id_tipo_cliente: str,
+    id_codigo_postal: str,
+) -> None:
+    """Crear un nuevo cliente en la base de datos."""
+
+    campos = [
+        documento,
+        nombre,
+        telefono,
+        direccion,
+        correo,
+        contrasena,
+        id_licencia,
+        id_tipo_documento,
+        id_tipo_cliente,
+        id_codigo_postal,
+    ]
+    if not all(campos):
+        raise DatosClienteInvalidos("Todos los campos son obligatorios")
+    if not validar_correo(correo):
+        raise DatosClienteInvalidos("Correo no válido")
+
+    hashed = sha256_hash(contrasena)
+    query = (
+        "INSERT INTO Cliente (documento, nombre, telefono, direccion, correo, "
+        "contrasena, infracciones, id_licencia, id_tipo_documento, "
+        "id_tipo_cliente, id_codigo_postal, id_cuenta) "
+        "VALUES (%s, %s, %s, %s, %s, %s, 0, %s, %s, %s, %s, NULL)"
+    )
+    conexion = ConexionBD()
+    conexion.ejecutar(
+        query,
+        (
+            documento,
+            nombre,
+            telefono,
+            direccion,
+            correo,
+            hashed,
+            id_licencia,
+            id_tipo_documento,
+            id_tipo_cliente,
+            id_codigo_postal,
+        ),
+    )

--- a/scripts/registro_cliente.py
+++ b/scripts/registro_cliente.py
@@ -1,0 +1,15 @@
+from utils.logger import configurar_logging
+from interfaces.registro_cliente import VentanaCrearCliente
+import tkinter as tk
+
+
+def main() -> None:
+    configurar_logging()
+    root = tk.Tk()
+    root.withdraw()
+    VentanaCrearCliente(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_crear_cliente.py
+++ b/tests/test_crear_cliente.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault('customtkinter', MagicMock())
+
+from logica.clientes import crear_cliente, DatosClienteInvalidos
+from utils.hash_utils import sha256_hash
+
+
+class CrearClienteTest(unittest.TestCase):
+    @patch('logica.clientes.ConexionBD')
+    def test_crear_cliente_exitoso(self, mock_conn_cls):
+        mock_conn = MagicMock()
+        mock_conn_cls.return_value = mock_conn
+
+        crear_cliente(
+            '1', 'Ana', '123', 'Calle 1',
+            'ana@example.com', 'secret', 'L1', 'TD', 'TC', 'CP'
+        )
+
+        mock_conn.ejecutar.assert_called_once()
+        args = mock_conn.ejecutar.call_args[0]
+        params = args[1]
+        self.assertEqual(params[5], sha256_hash('secret'))
+
+    def test_validacion_correo(self):
+        with self.assertRaises(DatosClienteInvalidos):
+            crear_cliente(
+                '1', 'Ana', '123', 'Calle 1',
+                'correo-invalido', 'x', 'L1', 'TD', 'TC', 'CP'
+            )
+
+    def test_campos_obligatorios(self):
+        with self.assertRaises(DatosClienteInvalidos):
+            crear_cliente('', '', '', '', '', '', '', '', '', '')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `crear_cliente` helper to register clients
- use new logic from the registration UI
- provide `scripts/registro_cliente.py` to open registration without login
- test client creation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad57bed54832baefaac6d4245f2f1