### PR TITLE
Implement fragmentation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,18 @@ en caso de fallo:
 ```bash
 python tests/simular_falla.py
 ```
+
+## Redundancia y Fragmentación
+
+El paquete `redundancia` ejecuta cada operación en dos bases de datos para mantener copias sincronizadas. Para la fragmentación se añadió el paquete `fragmentacion`, que distribuye las operaciones sobre la tabla `Cliente` en dos fragmentos simples según el identificador (pares a la base local e impares a la remota).
+
+```python
+from redundancia import GestorRedundancia
+from fragmentacion import GestorFragmentacion
+
+red = GestorRedundancia()
+frag = GestorFragmentacion()
+
+red.ejecutar("SELECT 1")
+frag.ejecutar("INSERT INTO Cliente VALUES (%s)", (2,))
+```

--- a/fragmentacion/__init__.py
+++ b/fragmentacion/__init__.py
@@ -1,0 +1,5 @@
+"""Módulos relacionados con fragmentación de datos."""
+
+from .gestor import GestorFragmentacion
+
+__all__ = ["GestorFragmentacion"]

--- a/fragmentacion/gestor.py
+++ b/fragmentacion/gestor.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, List, Tuple, Optional
+
+from conexion.conexion import ConexionBD
+
+
+class GestorFragmentacion:
+    """Ejecuta operaciones en el fragmento correcto."""
+
+    def __init__(self) -> None:
+        # Un fragmento por cada base
+        self.frag1 = ConexionBD(active="local", queue_file="pendientes_frag1.json")
+        self.frag2 = ConexionBD(active="remote", queue_file="pendientes_frag2.json")
+
+    def _seleccionar_fragmento(self, id_val: int) -> ConexionBD:
+        """Seleccionar fragmento por un criterio simple de par/impar."""
+        return self.frag1 if id_val % 2 == 0 else self.frag2
+
+    def ejecutar(self, query: str, params: Optional[Tuple[Any, ...]] = None) -> List[Tuple[Any, ...]]:
+        """Ejecutar la consulta en el fragmento determinado."""
+        conn = self.frag1
+        if "cliente" in query.lower() and params:
+            try:
+                id_val = int(params[0])
+                conn = self._seleccionar_fragmento(id_val)
+            except (ValueError, TypeError):
+                conn = self.frag1
+        return conn.ejecutar(query, params)

--- a/tests/test_fragmentacion.py
+++ b/tests/test_fragmentacion.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fragmentacion.gestor import GestorFragmentacion
+
+
+class FragmentacionTest(unittest.TestCase):
+    @patch('fragmentacion.gestor.ConexionBD')
+    def test_ruta_id_par(self, mock_conn):
+        frag1 = MagicMock()
+        frag2 = MagicMock()
+        mock_conn.side_effect = [frag1, frag2]
+        gestor = GestorFragmentacion()
+        gestor.ejecutar('INSERT INTO cliente VALUES (%s)', (2,))
+        frag1.ejecutar.assert_called_once()
+        frag2.ejecutar.assert_not_called()
+
+    @patch('fragmentacion.gestor.ConexionBD')
+    def test_ruta_id_impar(self, mock_conn):
+        frag1 = MagicMock()
+        frag2 = MagicMock()
+        mock_conn.side_effect = [frag1, frag2]
+        gestor = GestorFragmentacion()
+        gestor.ejecutar('INSERT INTO cliente VALUES (%s)', (3,))
+        frag2.ejecutar.assert_called_once()
+        frag1.ejecutar.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a basic fragmentation module
- include unit tests for fragmentation routing
- document redundancy and fragmentation in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ade7a429c832bb3dd61a3fcc6bb25