### PR TITLE
Fix query normalization logic

### DIFF
--- a/Consulta.py
+++ b/Consulta.py
@@ -38,7 +38,7 @@ class MySQLApp:
             r"SELECT|FROM|WHERE|INSERT|INTO|VALUES|UPDATE|SET|DELETE|JOIN|INNER|"
             r"LEFT|RIGHT|ON|GROUP|BY|ORDER|LIMIT|DISTINCT|AS|AND|OR|NOT|NULL"
         )
-        query = re.sub(fr"(?i)({keywords})", r" \1 ", query)
+        query = re.sub(fr"(?i)\b({keywords})\b", r" \1 ", query)
         return re.sub(r"\s+", " ", query).strip()
 
     def mostrar_tablas(self):

--- a/tests/test_normalizar_query.py
+++ b/tests/test_normalizar_query.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from Consulta import MySQLApp
+
+class NormalizarQueryTest(unittest.TestCase):
+    def test_keywords_inside_words_not_spaced(self):
+        app = MySQLApp.__new__(MySQLApp)
+        original = "INSERT INTO Tipo_documento (descripcion) VALUES ('Prueba documento');"
+        result = app._normalizar_query(original)
+        self.assertEqual(result, original)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure keyword spacing doesn't split regular words
- add unit test for query normalization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_685ae57daf94832babc9604d2ab87e2e