### PR TITLE
Enable redundant DB execution for admin queries

### DIFF
--- a/Consulta.py
+++ b/Consulta.py
@@ -6,10 +6,11 @@ from ttkthemes import ThemedTk
 from tkinter import filedialog
 from mysql.connector import Error, InterfaceError
 from conexion.conexion import ConexionBD
+from redundancia import GestorRedundancia
 
 
 class MySQLApp:
-    def __init__(self, root, conexion: ConexionBD | None = None):
+    def __init__(self, root, conexion: ConexionBD | GestorRedundancia | None = None):
         self.sql_keywords = [
             "SELECT", "FROM", "WHERE", "INSERT", "INTO", "VALUES", "UPDATE", "SET",
             "DELETE", "JOIN", "INNER", "LEFT", "RIGHT", "ON", "GROUP BY", "ORDER BY",
@@ -31,8 +32,8 @@ class MySQLApp:
 
     def _normalizar_query(self, query: str) -> str:
         """Inserta espacios entre palabras clave y símbolos para evitar errores."""
-        # Separar operadores y paréntesis
-        query = re.sub(r"([(),=*<>])", r" \1 ", query)
+        # Separar operadores comunes evitando alterar paréntesis
+        query = re.sub(r"([,=*<>])", r" \1 ", query)
         # Agregar espacios en keywords importantes
         keywords = (
             r"SELECT|FROM|WHERE|INSERT|INTO|VALUES|UPDATE|SET|DELETE|JOIN|INNER|"
@@ -265,11 +266,6 @@ class MySQLApp:
         # Guardar en historial
         self.actualizar_historial(query)
 
-        if not self.conexion.conn or not self.conexion.conn.is_connected():
-            self.conexion.conectar()
-        if not self.conexion.conn or not self.conexion.conn.is_connected():
-            mostrar_error(Exception("No hay conexión a la base de datos."))
-            return
 
         try:
             columnas, filas = self.conexion.ejecutar_con_columnas(query)

--- a/interfaces/admin.py
+++ b/interfaces/admin.py
@@ -5,7 +5,7 @@ from tkinter import ttk
 from ttkthemes import ThemedTk
 
 from Consulta import MySQLApp
-from conexion.conexion import ConexionBD
+from redundancia import GestorRedundancia
 from utils import cancel_pending_after, safe_bg_error_handler
 
 
@@ -43,7 +43,7 @@ class VentanaAdmin(ThemedTk):
 
         self.ventana_consulta = tk.Toplevel(self)
         self.btn_sql.config(state=tk.DISABLED)
-        MySQLApp(self.ventana_consulta, ConexionBD())
+        MySQLApp(self.ventana_consulta, GestorRedundancia())
         self.ventana_consulta.protocol("WM_DELETE_WINDOW", self._cerrar_consulta)
 
     def _logout(self) -> None:

--- a/redundancia/gestor.py
+++ b/redundancia/gestor.py
@@ -16,15 +16,15 @@ class GestorRedundancia:
     def ejecutar(self, query: str, params: Optional[Tuple[Any, ...]] = None) -> List[Tuple[Any, ...]]:
         """Ejecuta una consulta en ambas bases de datos.
 
-        Devuelve el resultado obtenido de la base remota si está
-        disponible; de lo contrario se devuelve el de la base local.
+        Devuelve el resultado obtenido de la base remota si está disponible;
+        de lo contrario devuelve el de la base local.
         """
         res_local: List[Tuple[Any, ...]] | None = None
         res_remota: List[Tuple[Any, ...]] | None = None
         try:
             res_local = self.local.ejecutar(query, params)
         except Exception:
-            # La lógica de ConexionBD ya gestiona el almacenamiento de pendientes
+            # ``ConexionBD`` ya maneja la cola de pendientes en caso de error
             pass
         try:
             res_remota = self.remota.ejecutar(query, params)
@@ -32,3 +32,34 @@ class GestorRedundancia:
             pass
 
         return res_remota if res_remota is not None else (res_local or [])
+
+    def ejecutar_con_columnas(
+        self, query: str, params: Optional[Tuple[Any, ...]] = None
+    ) -> Tuple[List[str], List[Tuple[Any, ...]]]:
+        """Versión con columnas de :meth:`ejecutar`.
+
+        Ejecuta la consulta en ambas bases y prioriza los resultados de la
+        remota si están disponibles.
+        """
+        cols_local: List[str] | None = None
+        res_local: List[Tuple[Any, ...]] | None = None
+        cols_remote: List[str] | None = None
+        res_remote: List[Tuple[Any, ...]] | None = None
+
+        try:
+            cols_local, res_local = self.local.ejecutar_con_columnas(query, params)
+        except Exception:
+            pass
+        try:
+            cols_remote, res_remote = self.remota.ejecutar_con_columnas(query, params)
+        except Exception:
+            pass
+
+        if cols_remote is not None:
+            return cols_remote, res_remote or []
+        return cols_local or [], res_local or []
+
+    def close(self) -> None:
+        """Cerrar ambas conexiones."""
+        self.local.close()
+        self.remota.close()

--- a/tests/test_redundancia.py
+++ b/tests/test_redundancia.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from redundancia.gestor import GestorRedundancia
+
+
+class RedundanciaTest(unittest.TestCase):
+    @patch('redundancia.gestor.ConexionBD')
+    def test_ejecutar_en_ambas_bases(self, mock_conn):
+        local = MagicMock()
+        remote = MagicMock()
+        mock_conn.side_effect = [local, remote]
+        gestor = GestorRedundancia()
+        gestor.ejecutar('INSERT INTO t VALUES (%s)', (1,))
+        local.ejecutar.assert_called_once_with('INSERT INTO t VALUES (%s)', (1,))
+        remote.ejecutar.assert_called_once_with('INSERT INTO t VALUES (%s)', (1,))
+
+    @patch('redundancia.gestor.ConexionBD')
+    def test_ejecutar_con_columnas_fallback_local(self, mock_conn):
+        local = MagicMock()
+        local.ejecutar_con_columnas.return_value = (['id'], [(1,)])
+        remote = MagicMock()
+        remote.ejecutar_con_columnas.side_effect = Exception('fail')
+        mock_conn.side_effect = [local, remote]
+        gestor = GestorRedundancia()
+        cols, rows = gestor.ejecutar_con_columnas('SELECT 1')
+        self.assertEqual(cols, ['id'])
+        self.assertEqual(rows, [(1,)])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve redundancy manager with `ejecutar_con_columnas` and `close`
- use `GestorRedundancia` in admin console
- support redundancy objects in `MySQLApp`
- fix query normalisation regex
- test redundancy manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae7b3a3c8832b84f422d1e201bcf3