### PR TITLE
Enable dual DB connections with separate queues

### DIFF
--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -11,17 +11,24 @@ from conexion.conexion import ConexionBD
 class ConexionDBTest(unittest.TestCase):
     @patch('conexion.conexion.mysql.connector.connect')
     def test_conectar_exitoso(self, mock_connect):
-        mock_conn = MagicMock()
-        mock_conn.is_connected.return_value = True
-        mock_connect.return_value = mock_conn
+        conn_remote = MagicMock()
+        conn_remote.is_connected.return_value = True
+        conn_local = MagicMock()
+        conn_local.is_connected.return_value = True
+        mock_connect.side_effect = [conn_remote, conn_local]
 
-        with patch.object(ConexionBD, '_cargar_pendientes', return_value=None), \
-             patch.object(ConexionBD, '_guardar_pendientes', return_value=None), \
-             patch.object(ConexionBD, '_sincronizar', return_value=None):
+        with patch.object(ConexionBD, '_cargar_pendientes_local', return_value=None), \
+             patch.object(ConexionBD, '_cargar_pendientes_remota', return_value=None), \
+             patch.object(ConexionBD, '_guardar_pendientes_local', return_value=None), \
+             patch.object(ConexionBD, '_guardar_pendientes_remota', return_value=None), \
+             patch.object(ConexionBD, '_sincronizar_local', return_value=None), \
+             patch.object(ConexionBD, '_sincronizar_remota', return_value=None):
             db = ConexionBD()
-            self.assertIs(db.conn, mock_conn)
-            self.assertTrue(db.conn.is_connected())
-            mock_connect.assert_called_once()
+            self.assertIs(db.conn_remota, conn_remote)
+            self.assertIs(db.conn_local, conn_local)
+            self.assertTrue(db.conn_remota.is_connected())
+            self.assertTrue(db.conn_local.is_connected())
+            self.assertEqual(mock_connect.call_count, 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_sync_fix.py
+++ b/tests/test_sync_fix.py
@@ -11,60 +11,60 @@ from conexion.conexion import ConexionBD
 class SyncFixTest(unittest.TestCase):
     def setUp(self):
         self.db = ConexionBD.__new__(ConexionBD)
-        self.db.conn = MagicMock()
-        self.db.conn.is_connected.return_value = True
-        self.db.pendientes = []
-        self.db.queue_file = '/tmp/pendientes_test.json'
+        self.db.conn_local = MagicMock()
+        self.db.conn_local.is_connected.return_value = True
+        self.db.pendientes_local = []
+        self.db.queue_file_local = '/tmp/pendientes_test_local.json'
 
     def test_fix_clientes_query(self):
         cursor = MagicMock()
-        self.db.conn.cursor.return_value = cursor
+        self.db.conn_local.cursor.return_value = cursor
         err = Error(msg="1146 (42S02): Table 'alquiler_vehiculos.clientes' doesn't exist")
         cursor.execute.side_effect = [err, None]
-        self.db.pendientes = [{
+        self.db.pendientes_local = [{
             'query': 'INSERT INTO clientes (nombre) VALUES (%s)',
             'params': ('Ana',)
         }]
-        self.db._sincronizar()
+        self.db._sincronizar_local()
         self.assertEqual(cursor.execute.call_args_list[1][0][0],
                          'INSERT INTO Cliente (nombre) VALUES (%s)')
 
     def test_fetch_select_results(self):
         cursor = MagicMock()
-        self.db.conn.cursor.return_value = cursor
+        self.db.conn_local.cursor.return_value = cursor
         cursor.execute.side_effect = [None]
         cursor.fetchall.return_value = [(1,)]
-        self.db.pendientes = [{
+        self.db.pendientes_local = [{
             'query': 'SELECT * FROM cliente',
             'params': None,
         }]
-        self.db._sincronizar()
+        self.db._sincronizar_local()
         cursor.fetchall.assert_called_once()
         cursor.close.assert_called_once()
 
     def test_fix_empleados_query(self):
         cursor = MagicMock()
-        self.db.conn.cursor.return_value = cursor
+        self.db.conn_local.cursor.return_value = cursor
         err = Error(msg="1146 (42S02): Table 'alquiler_vehiculos.empleados' doesn't exist")
         cursor.execute.side_effect = [err, None]
-        self.db.pendientes = [{
+        self.db.pendientes_local = [{
             'query': 'INSERT INTO empleados (nombre) VALUES (%s)',
             'params': ('Ana',)
         }]
-        self.db._sincronizar()
+        self.db._sincronizar_local()
         self.assertEqual(cursor.execute.call_args_list[1][0][0],
                          'INSERT INTO empleado (nombre) VALUES (%s)')
 
     def test_fetch_select_results(self):
         cursor = MagicMock()
-        self.db.conn.cursor.return_value = cursor
+        self.db.conn_local.cursor.return_value = cursor
         cursor.execute.side_effect = [None]
         cursor.fetchall.return_value = [(1,)]
-        self.db.pendientes = [{
+        self.db.pendientes_local = [{
             'query': 'SELECT * FROM empleado',
             'params': None,
         }]
-        self.db._sincronizar()
+        self.db._sincronizar_local()
         cursor.fetchall.assert_called_once()
         cursor.close.assert_called_once()
 


### PR DESCRIPTION
## Summary
- manage local and remote MySQL connections simultaneously
- keep independent pending-operation queues per connection
- update sync fix tests and DB connection test for new behaviour

## Testing
- `pip install -q mysql-connector-python ttkthemes tkcalendar python-dotenv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aece24014832b9717db22bf853f02