### PR TITLE
Update gestor instantiation

### DIFF
--- a/fragmentacion/gestor.py
+++ b/fragmentacion/gestor.py
@@ -17,10 +17,12 @@ class GestorFragmentacion:
         # Un fragmento por cada base
         self.frag1 = ConexionBD(
             active="local",
+            failover=False,
             queue_file_local="pendientes_frag1.json",
         )
         self.frag2 = ConexionBD(
             active="remote",
+            failover=False,
             queue_file_remota="pendientes_frag2.json",
         )
 

--- a/redundancia/gestor.py
+++ b/redundancia/gestor.py
@@ -12,10 +12,12 @@ class GestorRedundancia:
         # Conexión dedicada para cada base
         self.local = ConexionBD(
             active="local",
+            failover=False,
             queue_file_local="pendientes_local.json",
         )
         self.remota = ConexionBD(
             active="remote",
+            failover=False,
             queue_file_remota="pendientes_remota.json",
         )
 


### PR DESCRIPTION
## Summary
- disable failover in redundancia Gestor for both connections
- disable failover in fragmentacion Gestor for each fragment

## Testing
- `pytest -q` *(fails: ConexionDBTest.test_conectar_exitoso, SyncFixTest.test_fetch_select_results, SyncFixTest.test_fix_clientes_query, SyncFixTest.test_fix_empleados_query)*

------
https://chatgpt.com/codex/tasks/task_e_685af910f508832b8117b5baa361539d