### PR TITLE
Improve crear_cliente tests

### DIFF
--- a/tests/test_crear_cliente.py
+++ b/tests/test_crear_cliente.py
@@ -7,24 +7,26 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 sys.modules.setdefault('customtkinter', MagicMock())
 
 from logica.clientes import crear_cliente, DatosClienteInvalidos
-from utils.hash_utils import sha256_hash
 
 
 class CrearClienteTest(unittest.TestCase):
+    @patch('logica.clientes.sha256_hash')
     @patch('logica.clientes.ConexionBD')
-    def test_crear_cliente_exitoso(self, mock_conn_cls):
+    def test_crear_cliente_exitoso(self, mock_conn_cls, mock_hash):
         mock_conn = MagicMock()
         mock_conn_cls.return_value = mock_conn
+        mock_hash.return_value = 'hashed-secret'
 
         crear_cliente(
             '1', 'Ana', '123', 'Calle 1',
             'ana@example.com', 'secret', 'L1', 'TD', 'TC', 'CP'
         )
 
+        mock_hash.assert_called_once_with('secret')
         mock_conn.ejecutar.assert_called_once()
-        args = mock_conn.ejecutar.call_args[0]
-        params = args[1]
-        self.assertEqual(params[5], sha256_hash('secret'))
+        query, params = mock_conn.ejecutar.call_args[0]
+        self.assertIn('INSERT INTO Cliente', query)
+        self.assertEqual(params[5], 'hashed-secret')
 
     def test_validacion_correo(self):
         with self.assertRaises(DatosClienteInvalidos):
@@ -36,6 +38,18 @@ class CrearClienteTest(unittest.TestCase):
     def test_campos_obligatorios(self):
         with self.assertRaises(DatosClienteInvalidos):
             crear_cliente('', '', '', '', '', '', '', '', '', '')
+
+    def test_campos_obligatorios_individual(self):
+        valid = [
+            '1', 'Ana', '123', 'Calle 1',
+            'ana@example.com', 'secret', 'L1', 'TD', 'TC', 'CP'
+        ]
+        for idx in range(len(valid)):
+            inval = valid.copy()
+            inval[idx] = ''
+            with self.subTest(field=idx):
+                with self.assertRaises(DatosClienteInvalidos):
+                    crear_cliente(*inval)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- improve `CrearClienteTest`
- verify password hashing with `sha256_hash`
- mock DB insert and validate invalid input cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b06b9a264832b9ba5327091592201