### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,45 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/README.md b/README.md
-index ba453af836db8b7ea59b8c2b9232730e59bf938c..f89e4978d8e327e91bbdef527415f959603cecbc 100644
---- a/README.md
-+++ b/README.md
-@@ -10,25 +10,40 @@ MySQL con tolerancia a fallos.
- - Dependencias indicadas en `requirements.txt` (instalar con `pip install -r requirements.txt`)
- 
- ## Instalación
- 1. Crear un entorno virtual y activar.
- 2. Copiar el archivo `.env` y configurar las variables:
-    - `DB1_HOST`, `DB1_USER`, `DB1_PASSWORD`, `DB1_NAME`
-    - `DB2_HOST`, `DB2_USER`, `DB2_PASSWORD`, `DB2_NAME`
-    - `GOOGLE_MAPS_API_KEY` y `TWILIO_API_KEY`
- 3. Ejecutar los scripts de `scripts/` en la base local y remota:
-    ```bash
-    mysql -u root -p < scripts/crear_bd.sql
-    mysql -u root -p alquiler_vehiculos < scripts/poblar_bd.sql
-    ```
- 
- ## Uso
- Ejecutar `python main.py` para iniciar la interfaz de login. Según el rol del
- usuario se mostrará la ventana correspondiente. Todas las ventanas incluyen la
- opción de cerrar sesión.
- 
- ## Pruebas
- El directorio `tests` contiene `simular_falla.py` para probar el cambio de base
- en caso de fallo:
- ```bash
- python tests/simular_falla.py
- ```
-+
-+## Redundancia y Fragmentación
-+
-+El paquete `redundancia` ejecuta cada operación en dos bases de datos para mantener copias sincronizadas. Para la fragmentación se añadió el paquete `fragmentacion`, que distribuye las operaciones sobre la tabla `Cliente` en dos fragmentos simples según el identificador (pares a la base local e impares a la remota).
-+
-+```python
-+from redundancia import GestorRedundancia
-+from fragmentacion import GestorFragmentacion
-+
-+red = GestorRedundancia()
-+frag = GestorFragmentacion()
-+
-+red.ejecutar("SELECT 1")
-+frag.ejecutar("INSERT INTO Cliente VALUES (%s)", (2,))
-+```
- 
-EOF
-)
+# Sistema de Gestión de Alquiler de Vehículos
+
+Este proyecto es un ejemplo académico para la materia Bases de Datos Distribuidas.
+Incluye una aplicación en Python con autenticación por roles y soporte para bases MySQL con tolerancia a fallos.
+
+## Requisitos
+- Python 3.10+
+- MySQL Server
+- Dependencias indicadas en `requirements.txt` (instalar con `pip install -r requirements.txt`)
+
+## Instalación
+1. Crear un entorno virtual y activar.
+2. Copiar el archivo `.env` y configurar las variables:
+   - `DB1_HOST`, `DB1_USER`, `DB1_PASSWORD`, `DB1_NAME`
+   - `DB2_HOST`, `DB2_USER`, `DB2_PASSWORD`, `DB2_NAME`
+   - `GOOGLE_MAPS_API_KEY` y `TWILIO_API_KEY`
+3. Ejecutar los scripts de `scripts/` en la base local y remota:
+   ```bash
+   mysql -u root -p < scripts/crear_bd.sql
+   mysql -u root -p alquiler_vehiculos < scripts/poblar_bd.sql
+   ```
+
+## Uso
+Ejecutar `python main.py` para iniciar la interfaz de login. Según el rol del usuario se mostrará la ventana correspondiente. Todas las ventanas incluyen la opción de cerrar sesión.
+
+## Pruebas
+El directorio `tests` contiene `simular_falla.py` para probar el cambio de base en caso de fallo:
+```bash
+python tests/simular_falla.py
+```
+
+## Redundancia y Fragmentación
+
+El paquete `redundancia` ejecuta cada operación en dos bases de datos para mantener copias sincronizadas. Para la fragmentación se añadió el paquete `fragmentacion`, que distribuye las operaciones sobre la tabla `Cliente` en dos fragmentos simples según el identificador (pares a la base local e impares a la remota).
+
+```python
+from redundancia import GestorRedundancia
+from fragmentacion import GestorFragmentacion
+
+red = GestorRedundancia()
+frag = GestorFragmentacion()
+
+red.ejecutar("SELECT 1")
+frag.ejecutar("INSERT INTO Cliente VALUES (%s)", (2,))
+```


### PR DESCRIPTION
## Summary
- undo patch artifact in README
- restore Markdown sections for installation, usage and redundancy/fragmentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b097f8fdc832b99f669788750e7a3