### PR TITLE
Switch interface windows to Toplevel

### DIFF
--- a/interfaces/admin.py
+++ b/interfaces/admin.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk
-from ttkthemes import ThemedTk
 
 from Consulta import MySQLApp
 from redundancia import GestorRedundancia
 from utils import cancel_pending_after, safe_bg_error_handler
 
 
-class VentanaAdmin(ThemedTk):
-    def __init__(self) -> None:
-        super().__init__(theme="arc")
+class VentanaAdmin(tk.Toplevel):
+    def __init__(self, master: tk.Misc) -> None:
+        super().__init__(master)
+        estilo = ttk.Style(self)
+        try:
+            estilo.theme_use("arc")
+        except Exception:
+            pass
         self.report_callback_exception = safe_bg_error_handler
         self._after_ids: list[str] = []
         self.title("🛠️ Panel del Administrador")
@@ -50,11 +54,9 @@ class VentanaAdmin(ThemedTk):
         if self.ventana_consulta and self.ventana_consulta.winfo_exists():
             self.ventana_consulta.destroy()
         cancel_pending_after(self)
-        self.quit()
         self.destroy()
-        from interfaces.login import VentanaLogin
-
-        VentanaLogin().mainloop()
+        if self.master is not None:
+            self.master.deiconify()
 
     def _cerrar_consulta(self) -> None:
         if self.ventana_consulta:

--- a/interfaces/cliente.py
+++ b/interfaces/cliente.py
@@ -77,11 +77,11 @@ class SimpleDateEntry(ttk.Frame):
             return date.today()
 
 
-class VentanaCliente(ctk.CTk):
+class VentanaCliente(ctk.CTkToplevel):
     """Panel principal del cliente con pesta\u00f1as."""
 
-    def __init__(self, id_cliente: int) -> None:
-        super().__init__()
+    def __init__(self, master: tk.Misc, id_cliente: int) -> None:
+        super().__init__(master)
         self.report_callback_exception = safe_bg_error_handler
         self._after_ids: list[str] = []
         self.id_cliente = id_cliente
@@ -614,11 +614,9 @@ class VentanaCliente(ctk.CTk):
 
     # ------------------------------------------------------------------
     def _logout(self) -> None:
-        from utils import cancel_pending_after
 
         cancel_pending_after(self)
-        self.quit()
         self.destroy()
-        from interfaces.login import VentanaLogin
+        if self.master is not None:
+            self.master.deiconify()
 
-        VentanaLogin().mainloop()

--- a/interfaces/empleado.py
+++ b/interfaces/empleado.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import messagebox, ttk
 
-from ttkthemes import ThemedTk
 
 import logging
 
@@ -17,9 +16,14 @@ from utils import (
 )
 
 
-class VentanaEmpleado(ThemedTk):
-    def __init__(self) -> None:
-        super().__init__(theme="arc")
+class VentanaEmpleado(tk.Toplevel):
+    def __init__(self, master: tk.Misc) -> None:
+        super().__init__(master)
+        self.style = ttk.Style(self)
+        try:
+            self.style.theme_use("arc")
+        except Exception:
+            pass
         self.report_callback_exception = safe_bg_error_handler
         self._after_ids: list[str] = []
         self.title("🧑‍🔧 Panel del Empleado")
@@ -75,11 +79,9 @@ class VentanaEmpleado(ThemedTk):
         for win in list(self._subventanas):
             win.destroy()
         cancel_pending_after(self)
-        self.quit()
         self.destroy()
-        from interfaces.login import VentanaLogin
-
-        VentanaLogin().mainloop()
+        if self.master is not None:
+            self.master.deiconify()
 
 
 class VentanaGestionReservas(tk.Toplevel):

--- a/interfaces/gerente.py
+++ b/interfaces/gerente.py
@@ -16,11 +16,11 @@ ctk.set_appearance_mode("dark")
 ctk.set_default_color_theme("blue")
 
 
-class VentanaGerente(ctk.CTk):
+class VentanaGerente(ctk.CTkToplevel):
     """Panel principal para el rol de gerente."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, master: tk.Misc) -> None:
+        super().__init__(master)
         self.report_callback_exception = safe_bg_error_handler
         self._after_ids: list[str] = []
         self.conexion = ConexionBD()
@@ -342,8 +342,6 @@ class VentanaGerente(ctk.CTk):
     # ------------------------------------------------------------------
     def _logout(self) -> None:
         cancel_pending_after(self)
-        self.quit()
         self.destroy()
-        from interfaces.login import VentanaLogin
-
-        VentanaLogin().mainloop()
+        if self.master is not None:
+            self.master.deiconify()

--- a/interfaces/login.py
+++ b/interfaces/login.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from tkinter import messagebox
 import customtkinter as ctk
-from utils import cancel_pending_after, safe_bg_error_handler
+from utils import safe_bg_error_handler
 
 ctk.set_appearance_mode("dark")  # o "light"
 ctk.set_default_color_theme("blue")
@@ -82,31 +82,31 @@ class VentanaLogin(ctk.CTk):
             return
 
         rol = self._normalizar_rol(rol)
-        cancel_pending_after(self)
-        self.quit()
-        self.destroy()
+        self.withdraw()
         if rol == "cliente":
             from interfaces.cliente import VentanaCliente
 
             id_cliente = self.autenticador.obtener_id_cliente(correo)
             if id_cliente is None:
                 messagebox.showerror("Error", "Cliente no encontrado")
+                self.deiconify()
                 return
-            VentanaCliente(id_cliente).mainloop()
+            VentanaCliente(self, id_cliente)
         elif rol == "empleado":
             from interfaces.empleado import VentanaEmpleado
 
-            VentanaEmpleado().mainloop()
+            VentanaEmpleado(self)
         elif rol == "gerente":
             from interfaces.gerente import VentanaGerente
 
-            VentanaGerente().mainloop()
+            VentanaGerente(self)
         elif rol == "admin":
             from interfaces.admin import VentanaAdmin
 
-            VentanaAdmin().mainloop()
+            VentanaAdmin(self)
         else:
             messagebox.showerror("Error", "Rol desconocido")
+            self.deiconify()
 
     def _abrir_registro(self) -> None:
         from interfaces.registro_cliente import VentanaCrearCliente


### PR DESCRIPTION
## Summary
- make role windows inherit from `CTkToplevel` or `Toplevel`
- hide login window and spawn role windows as children
- update logout logic to return to login

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b760fd908832bb2f566a63bbef76a