### PR TITLE
Implement GestorRedundanciaRespaldo

### DIFF
--- a/redundancia/__init__.py
+++ b/redundancia/__init__.py
@@ -1,5 +1,5 @@
 """Módulos relacionados con tolerancia a fallos y sincronización."""
 
-from .gestor import GestorRedundancia
+from .gestor import GestorRedundanciaRespaldo
 
-__all__ = ["GestorRedundancia"]
+__all__ = ["GestorRedundanciaRespaldo"]


### PR DESCRIPTION
## Summary
- replace redundancy manager with `GestorRedundanciaRespaldo`
- export new class in `redundancia.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_685c5578aef8832ba80e6fa35954c049